### PR TITLE
ci(sil): embsim pin-bump gate + plant model tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,36 @@ jobs:
       - name: Run full ProtoEmb test suite
         run: make test
 
+  # embsim library suite against the *pinned submodule commit* (mirror of
+  # protoemb-ci). Upstream also runs this on RileyMcCarthy/embsim; re-running
+  # here gates pin bumps and catches unpushed / never-CI'd gitlinks. The MaD
+  # SIL workspace only *compiles* path deps (sil-rust) — this job executes the
+  # framework tests themselves.
+  embsim-ci:
+    needs: changes
+    if: needs.changes.outputs.sil == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: SIL/embsim
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: SIL/embsim
+      - name: Build (all targets)
+        run: cargo build --workspace --all-targets
+      - name: Test
+        run: cargo test --workspace --all-targets
+      - name: Doc tests
+        run: cargo test --workspace --doc
+      - name: Test embsim-trace (web off)
+        run: cargo test -p embsim-trace --no-default-features
+
   # Firmware Unity unit tests on the host (platform = native, AddressSanitizer).
   # No Propeller toolchain needed; the platformio pre-hook regenerates the C
   # protocol from the YAML and installs its own generator deps.
@@ -254,8 +284,8 @@ jobs:
       - name: Cargo test (blocking)
         working-directory: SIL
         # The workspace is the MaD-side crates only (protocol, models,
-        # MaDSim); the embsim submodule's crates are tested
-        # in their own repo's CI.
+        # MaDSim). The embsim submodule suite is re-run by the sibling
+        # `embsim-ci` job (mirror of protoemb-ci) on the pinned commit.
         run: cargo test --workspace --all-targets
 
   # BLOCKING. MISRA/cppcheck via `pio check`. Low severity is disabled in
@@ -802,6 +832,7 @@ jobs:
       - changes
       - wasm-control-ci
       - protoemb-ci
+      - embsim-ci
       - firmware-unit-tests
       - protocol-codegen
       - firmware-layering

--- a/SIL/Cargo.lock
+++ b/SIL/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +258,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "embsim-board"
+version = "0.1.0"
+dependencies = [
+ "embsim-core",
+ "embsim-peripherals",
+ "libc",
+ "nix",
+ "tracing",
+]
+
+[[package]]
 name = "embsim-build"
 version = "0.1.0"
 
@@ -273,6 +293,7 @@ dependencies = [
 name = "embsim-models"
 version = "0.1.0"
 dependencies = [
+ "embsim-board",
  "embsim-core",
  "libc",
  "nix",
@@ -381,6 +402,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,12 +425,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "pin-project-lite",
@@ -439,6 +478,12 @@ dependencies = [
  "indexmap",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
@@ -655,6 +700,7 @@ version = "0.1.0"
 dependencies = [
  "embsim-core",
  "embsim-models",
+ "rstest",
  "tracing",
 ]
 
@@ -753,6 +799,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,6 +874,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rstest"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ruzstd"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,6 +967,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1047,6 +1182,36 @@ dependencies = [
  "log",
  "tokio",
  "tungstenite",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -1297,6 +1462,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/SIL/models/Cargo.toml
+++ b/SIL/models/Cargo.toml
@@ -11,3 +11,6 @@ publish = false
 embsim-core = { path = "../embsim/core" }
 embsim-models = { path = "../embsim/models" }
 tracing.workspace = true
+
+[dev-dependencies]
+rstest = "0.25"

--- a/SIL/models/src/gantry.rs
+++ b/SIL/models/src/gantry.rs
@@ -94,3 +94,52 @@ impl Gantry {
     }
 }
 
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
+    use std::sync::Mutex;
+
+    fn default_cfg() -> Config {
+        Config {
+            engagement_slack_mm: 1.0,
+            tension_on_decreasing_position: true,
+            upper_threshold_mm: 5.0,
+            lower_threshold_mm: 50.0,
+        }
+    }
+
+    #[rstest]
+    #[case::at_baseline(0.0, 0.0)]
+    #[case::within_slack(0.5, 0.0)]
+    #[case::past_slack(3.0, 2.0)] // travel 3 - slack 1 = 2
+    fn extension_after_slack_on_decreasing(#[case] drop_mm: f64, #[case] expected_ext: f64) {
+        let g = Gantry::new(default_cfg());
+        let last = std::sync::Arc::new(Mutex::new(None));
+        {
+            let last = std::sync::Arc::clone(&last);
+            g.on_extension_change(move |e| *last.lock().unwrap() = Some(e));
+        }
+        g.on_position(100.0); // baseline
+        g.on_position(100.0 - drop_mm);
+        assert!((last.lock().unwrap().unwrap() - expected_ext).abs() < 1e-9);
+    }
+
+    #[rstest]
+    fn upper_limit_fires_once_on_edge() {
+        let g = Gantry::new(default_cfg());
+        let hits = std::sync::Arc::new(AtomicU32::new(0));
+        {
+            let hits = std::sync::Arc::clone(&hits);
+            g.on_upper_change(move |_| {
+                hits.fetch_add(1, AtomicOrdering::Relaxed);
+            });
+        }
+        g.on_position(10.0); // above upper threshold (5)
+        g.on_position(4.0); // cross below upper
+        g.on_position(3.0); // stay below — no new edge
+        assert_eq!(hits.load(AtomicOrdering::Relaxed), 1);
+    }
+}

--- a/SIL/models/src/sample.rs
+++ b/SIL/models/src/sample.rs
@@ -140,3 +140,60 @@ fn calculate_force(extension_mm: f64, config: &Config) -> f64 {
 
     extension_mm * stiffness
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
+    use std::sync::Mutex;
+
+    #[rstest]
+    #[case::zero(0.0, 0.0)]
+    #[case::negative(-1.0, 0.0)]
+    #[case::one_mm(1.0, 2.5)]
+    #[case::ten_mm(10.0, 25.0)]
+    fn linear_stiffness_force(#[case] extension_mm: f64, #[case] expected_n: f64) {
+        let cfg = Config {
+            stiffness_n_per_mm: 2.5,
+            tension_on_decreasing_position: true,
+            material: None,
+        };
+        let got = calculate_force(extension_mm, &cfg);
+        assert!((got - expected_n).abs() < 1e-9, "got {got} expected {expected_n}");
+    }
+
+    #[rstest]
+    fn material_properties_override_stiffness() {
+        // k = E * A / L0 = 100 * 2 / 10 = 20 N/mm
+        let cfg = Config {
+            stiffness_n_per_mm: 999.0, // ignored when material is valid
+            tension_on_decreasing_position: true,
+            material: Some(MaterialProperties {
+                name: "test",
+                youngs_modulus_mpa: 100.0,
+                area_mm2: 2.0,
+                gauge_length_mm: 10.0,
+            }),
+        };
+        assert!((calculate_force(1.0, &cfg) - 20.0).abs() < 1e-9);
+    }
+
+    #[rstest]
+    fn on_extension_notifies_subscribers() {
+        let sample = Sample::new(Config::default());
+        let last = std::sync::Arc::new(Mutex::new(None));
+        let hits = std::sync::Arc::new(AtomicU32::new(0));
+        {
+            let last = std::sync::Arc::clone(&last);
+            let hits = std::sync::Arc::clone(&hits);
+            sample.on_change(move |f| {
+                *last.lock().unwrap() = Some(f);
+                hits.fetch_add(1, AtomicOrdering::Relaxed);
+            });
+        }
+        sample.on_extension(4.0); // 4 * 2.5 = 10 N
+        assert_eq!(hits.load(AtomicOrdering::Relaxed), 1);
+        assert!((last.lock().unwrap().unwrap() - 10.0).abs() < 1e-9);
+    }
+}

--- a/SIL/models/src/strain_gauge.rs
+++ b/SIL/models/src/strain_gauge.rs
@@ -81,3 +81,49 @@ impl StrainGauge {
         (force_n / self.config.full_scale_force_n) * self.config.full_scale_mv()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
+    use std::sync::Mutex;
+
+    fn cfg() -> Config {
+        Config {
+            full_scale_force_n: 1000.0,
+            sensitivity_mv_per_v: 2.0,
+            excitation_v: 5.0, // full scale = 10 mV
+        }
+    }
+
+    #[rstest]
+    #[case::zero(0.0, 0.0)]
+    #[case::half(500.0, 5.0)]
+    #[case::full(1000.0, 10.0)]
+    fn force_to_voltage_linear(#[case] force_n: f64, #[case] expected_mv: f64) {
+        let g = StrainGauge::new(cfg());
+        let last = std::sync::Arc::new(Mutex::new(None));
+        {
+            let last = std::sync::Arc::clone(&last);
+            g.on_change(move |v| *last.lock().unwrap() = Some(v));
+        }
+        g.set_force(force_n);
+        assert!((last.lock().unwrap().unwrap() - expected_mv).abs() < 1e-9);
+    }
+
+    #[rstest]
+    fn set_force_notifies_once_per_call() {
+        let g = StrainGauge::new(cfg());
+        let hits = std::sync::Arc::new(AtomicU32::new(0));
+        {
+            let hits = std::sync::Arc::clone(&hits);
+            g.on_change(move |_| {
+                hits.fetch_add(1, AtomicOrdering::Relaxed);
+            });
+        }
+        g.set_force(1.0);
+        g.set_force(2.0);
+        assert_eq!(hits.load(AtomicOrdering::Relaxed), 2);
+    }
+}


### PR DESCRIPTION
## Summary

- **`embsim-ci` job** (mirror of `protoemb-ci`): on SIL-related path filter, recursive checkout, run the **pinned** `SIL/embsim` suite (`cargo test --workspace --all-targets`, doc tests, headless trace). Added to **CI Gate**.
- **Submodule pin** → embsim `main` @ `7c3db49` ([embsim#10](https://github.com/RileyMcCarthy/embsim/pull/10) merged): full `#[rstest]` rewrite, baud/pulse timing contracts, multi-instance isolation, soft coverage CI.
- **MaD plant models unit tests** (`SIL/models`): sample stiffness/force, gantry slack/extension + limit edge, strain-gauge force→mV matrices.

Rebased onto `main` only (dropped unrelated bug-class-coverage commit that was breaking `wasm-control-ci`).

## Test plan

- [x] `cargo test -p models` (14 cases)
- [x] embsim suite green at pin
- [x] embsim#10 merged
- [ ] MaD CI: `embsim-ci` + `sil-rust` + CI Gate green