### PR TITLE
test: Sprint B matrices — M4/M5/M7 + store event reduce

### DIFF
--- a/Firmware/MaDCore/test/test_app_control/test_app_control.c
+++ b/Firmware/MaDCore/test/test_app_control/test_app_control.c
@@ -30,6 +30,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 #include "HAL_lock.h"
 #include "HAL_GPIO.h"
@@ -146,6 +147,10 @@ static void doubles_reset(void)
 
 static void control_init(void)
 {
+    /* Matrix tests call control_init() many times in one RUN_TEST; reset the
+     * lock pool so we never exhaust the mock's 8-slot table mid-test. */
+    HAL_lock_mock_reset();
+    _stdio_debug_lock = HAL_lock_create();
     doubles_reset();
     /* app_control_data is a single file-static instance and app_control_init()
      * only assigns a few fields — the motionEnabled latch and pending request
@@ -470,6 +475,233 @@ void test_request_motionDisabledAlwaysLatches(void)
 }
 
 /**********************************************************************
+ * M4 — fault × restriction matrices (parameterized tables)
+ **********************************************************************/
+
+/* Trip exactly one fault source, leave all others healthy. */
+static void trip_fault_only(app_control_fault_E fault)
+{
+    doubles_reset();
+    d_cogAllRunning = true;
+    d_watchdogAlive = true;
+    d_stepperReady = true;
+    d_forceGaugeReady = true;
+    memset(d_gpio, 0, sizeof(d_gpio));
+    switch (fault)
+    {
+    case APP_CONTROL_FAULT_COG:
+        d_cogAllRunning = false;
+        break;
+    case APP_CONTROL_FAULT_WATCHDOG:
+        d_watchdogAlive = false;
+        break;
+    case APP_CONTROL_FAULT_ESD_POWER:
+        d_gpio[HAL_GPIO_ESD_POWER] = true;
+        break;
+    case APP_CONTROL_FAULT_ESD_SWITCH:
+        d_gpio[HAL_GPIO_ESD_SWITCH] = true;
+        break;
+    case APP_CONTROL_FAULT_ESD_UPPER:
+        d_gpio[HAL_GPIO_ESD_UPPER] = true;
+        break;
+    case APP_CONTROL_FAULT_ESD_LOWER:
+        d_gpio[HAL_GPIO_ESD_LOWER] = true;
+        break;
+    case APP_CONTROL_FAULT_SERVO_COMMUNICATION:
+        d_stepperReady = false;
+        break;
+    case APP_CONTROL_FAULT_FORCE_GAUGE_COMMUNICATION:
+        d_forceGaugeReady = false;
+        break;
+    case APP_CONTROL_FAULT_NONE:
+    case APP_CONTROL_FAULT_COUNT:
+    default:
+        break;
+    }
+}
+
+/* Every non-NONE fault alone → getFault() == that fault, state DISABLED. */
+void test_m4_each_fault_alone_reported_and_disables(void)
+{
+    static const app_control_fault_E faults[] = {
+        APP_CONTROL_FAULT_COG,
+        APP_CONTROL_FAULT_WATCHDOG,
+        APP_CONTROL_FAULT_ESD_POWER,
+        APP_CONTROL_FAULT_ESD_SWITCH,
+        APP_CONTROL_FAULT_ESD_UPPER,
+        APP_CONTROL_FAULT_ESD_LOWER,
+        APP_CONTROL_FAULT_SERVO_COMMUNICATION,
+        APP_CONTROL_FAULT_FORCE_GAUGE_COMMUNICATION,
+    };
+    for (size_t i = 0; i < sizeof(faults) / sizeof(faults[0]); i++)
+    {
+        control_init();
+        trip_fault_only(faults[i]);
+        app_control_run();
+        TEST_ASSERT_EQUAL_INT(faults[i], app_control_getFault());
+        TEST_ASSERT_EQUAL_INT(APP_CONTROL_STATE_DISABLED, app_control_data.state);
+        TEST_ASSERT_FALSE(app_control_motionEnabled());
+    }
+}
+
+/* Enable is refused while each fault is latched. */
+void test_m4_enable_refused_for_each_fault(void)
+{
+    static const app_control_fault_E faults[] = {
+        APP_CONTROL_FAULT_COG,
+        APP_CONTROL_FAULT_WATCHDOG,
+        APP_CONTROL_FAULT_ESD_POWER,
+        APP_CONTROL_FAULT_ESD_SWITCH,
+        APP_CONTROL_FAULT_ESD_UPPER,
+        APP_CONTROL_FAULT_ESD_LOWER,
+        APP_CONTROL_FAULT_SERVO_COMMUNICATION,
+        APP_CONTROL_FAULT_FORCE_GAUGE_COMMUNICATION,
+    };
+    for (size_t i = 0; i < sizeof(faults) / sizeof(faults[0]); i++)
+    {
+        control_init();
+        trip_fault_only(faults[i]);
+        app_control_run();
+        TEST_ASSERT_FALSE(app_control_triggerMotionEnabled());
+        app_control_run();
+        TEST_ASSERT_FALSE(app_control_motionEnabled());
+        TEST_ASSERT_EQUAL_INT(APP_CONTROL_STATE_DISABLED, app_control_data.state);
+    }
+}
+
+/* First-fault-wins across consecutive enum pairs (i beats i+1). */
+void test_m4_first_fault_wins_adjacent_pairs(void)
+{
+    /* Pair sources that can be co-asserted via independent doubles. */
+    typedef struct
+    {
+        app_control_fault_E lower;
+        app_control_fault_E higher;
+    } pair_t;
+    static const pair_t pairs[] = {
+        {APP_CONTROL_FAULT_COG, APP_CONTROL_FAULT_WATCHDOG},
+        {APP_CONTROL_FAULT_WATCHDOG, APP_CONTROL_FAULT_ESD_POWER},
+        {APP_CONTROL_FAULT_ESD_POWER, APP_CONTROL_FAULT_ESD_SWITCH},
+        {APP_CONTROL_FAULT_ESD_SWITCH, APP_CONTROL_FAULT_ESD_UPPER},
+        {APP_CONTROL_FAULT_ESD_UPPER, APP_CONTROL_FAULT_ESD_LOWER},
+        {APP_CONTROL_FAULT_ESD_LOWER, APP_CONTROL_FAULT_SERVO_COMMUNICATION},
+        {APP_CONTROL_FAULT_SERVO_COMMUNICATION, APP_CONTROL_FAULT_FORCE_GAUGE_COMMUNICATION},
+    };
+    for (size_t i = 0; i < sizeof(pairs) / sizeof(pairs[0]); i++)
+    {
+        control_init();
+        /* Assert both; lower index must win. */
+        trip_fault_only(pairs[i].lower);
+        /* Add the higher fault without clearing the lower. */
+        switch (pairs[i].higher)
+        {
+        case APP_CONTROL_FAULT_WATCHDOG:
+            d_watchdogAlive = false;
+            break;
+        case APP_CONTROL_FAULT_ESD_POWER:
+            d_gpio[HAL_GPIO_ESD_POWER] = true;
+            break;
+        case APP_CONTROL_FAULT_ESD_SWITCH:
+            d_gpio[HAL_GPIO_ESD_SWITCH] = true;
+            break;
+        case APP_CONTROL_FAULT_ESD_UPPER:
+            d_gpio[HAL_GPIO_ESD_UPPER] = true;
+            break;
+        case APP_CONTROL_FAULT_ESD_LOWER:
+            d_gpio[HAL_GPIO_ESD_LOWER] = true;
+            break;
+        case APP_CONTROL_FAULT_SERVO_COMMUNICATION:
+            d_stepperReady = false;
+            break;
+        case APP_CONTROL_FAULT_FORCE_GAUGE_COMMUNICATION:
+            d_forceGaugeReady = false;
+            break;
+        default:
+            break;
+        }
+        app_control_run();
+        TEST_ASSERT_EQUAL_INT(pairs[i].lower, app_control_getFault());
+    }
+}
+
+/* Active (non-commented) restrictions each alone → RESTRICTED when motion on. */
+void test_m4_each_active_restriction_alone(void)
+{
+    /* MACHINE_TENSION */
+    control_init();
+    enableMotion();
+    d_machineForce = 5001;
+    app_control_run();
+    TEST_ASSERT_EQUAL_INT(APP_CONTROL_RESTRICTION_MACHINE_TENSION, app_control_getRestriction());
+    TEST_ASSERT_EQUAL_INT(APP_CONTROL_STATE_RESTRICTED, app_control_data.state);
+    TEST_ASSERT_TRUE(app_control_speedLimited());
+
+    control_init();
+    enableMotion();
+    d_gpio[HAL_GPIO_ENDSTOP_UPPER] = true;
+    app_control_run();
+    TEST_ASSERT_EQUAL_INT(APP_CONTROL_RESTRICTION_UPPER_ENDSTOP, app_control_getRestriction());
+    TEST_ASSERT_EQUAL_INT(APP_CONTROL_STATE_RESTRICTED, app_control_data.state);
+
+    control_init();
+    enableMotion();
+    d_gpio[HAL_GPIO_ENDSTOP_LOWER] = true;
+    app_control_run();
+    TEST_ASSERT_EQUAL_INT(APP_CONTROL_RESTRICTION_LOWER_ENDSTOP, app_control_getRestriction());
+    TEST_ASSERT_EQUAL_INT(APP_CONTROL_STATE_RESTRICTED, app_control_data.state);
+
+    control_init();
+    enableMotion();
+    d_gpio[HAL_GPIO_ENDSTOP_DOOR] = true;
+    app_control_run();
+    TEST_ASSERT_EQUAL_INT(APP_CONTROL_RESTRICTION_DOOR, app_control_getRestriction());
+    TEST_ASSERT_EQUAL_INT(APP_CONTROL_STATE_RESTRICTED, app_control_data.state);
+}
+
+/* Sample length/tension paths are currently compiled out (commented) — pin that
+ * they stay inactive so re-enabling them without tests fails this lock. */
+void test_m4_sample_restrictions_inactive_today(void)
+{
+    control_init();
+    enableMotion();
+    d_testRunning = true;
+    d_machineForce = 0; /* no machine tension */
+    app_control_run();
+    TEST_ASSERT_FALSE(app_control_data.restriction[APP_CONTROL_RESTRICTION_SAMPLE_LENGTH]);
+    TEST_ASSERT_FALSE(app_control_data.restriction[APP_CONTROL_RESTRICTION_SAMPLE_TENSION]);
+    /* Still TEST (no active restriction). */
+    TEST_ASSERT_EQUAL_INT(APP_CONTROL_STATE_TEST, app_control_data.state);
+}
+
+/* Restriction priority chain: MACHINE_TENSION < UPPER < LOWER < DOOR indices. */
+void test_m4_restriction_priority_chain(void)
+{
+    control_init();
+    enableMotion();
+    d_machineForce = 99999; /* idx MACHINE_TENSION */
+    d_gpio[HAL_GPIO_ENDSTOP_UPPER] = true;
+    d_gpio[HAL_GPIO_ENDSTOP_LOWER] = true;
+    d_gpio[HAL_GPIO_ENDSTOP_DOOR] = true;
+    app_control_run();
+    TEST_ASSERT_EQUAL_INT(APP_CONTROL_RESTRICTION_MACHINE_TENSION, app_control_getRestriction());
+
+    control_init();
+    enableMotion();
+    d_gpio[HAL_GPIO_ENDSTOP_UPPER] = true;
+    d_gpio[HAL_GPIO_ENDSTOP_LOWER] = true;
+    d_gpio[HAL_GPIO_ENDSTOP_DOOR] = true;
+    app_control_run();
+    TEST_ASSERT_EQUAL_INT(APP_CONTROL_RESTRICTION_UPPER_ENDSTOP, app_control_getRestriction());
+
+    control_init();
+    enableMotion();
+    d_gpio[HAL_GPIO_ENDSTOP_LOWER] = true;
+    d_gpio[HAL_GPIO_ENDSTOP_DOOR] = true;
+    app_control_run();
+    TEST_ASSERT_EQUAL_INT(APP_CONTROL_RESTRICTION_LOWER_ENDSTOP, app_control_getRestriction());
+}
+
+/**********************************************************************
  * main
  **********************************************************************/
 
@@ -506,6 +738,13 @@ int main(void)
     RUN_TEST(test_request_motionEnabledTakesEffectNextRun);
     RUN_TEST(test_request_motionEnabledRefusedWhileFaulted);
     RUN_TEST(test_request_motionDisabledAlwaysLatches);
+
+    RUN_TEST(test_m4_each_fault_alone_reported_and_disables);
+    RUN_TEST(test_m4_enable_refused_for_each_fault);
+    RUN_TEST(test_m4_first_fault_wins_adjacent_pairs);
+    RUN_TEST(test_m4_each_active_restriction_alone);
+    RUN_TEST(test_m4_sample_restrictions_inactive_today);
+    RUN_TEST(test_m4_restriction_priority_chain);
 
     return UNITY_END();
 }

--- a/Firmware/MaDCore/test/test_app_messageSlave/test_app_messageSlave.c
+++ b/Firmware/MaDCore/test/test_app_messageSlave/test_app_messageSlave.c
@@ -257,6 +257,32 @@ void test_onWrite_test_run_busy_ends_then_starts(void)
     TEST_ASSERT_EQUAL_STRING("td0002", d_testName);
 }
 
+/* M5 bridge matrix: start NACK when triggerTestStart fails; END only when busy. */
+void test_m5_onWrite_test_run_start_nack_when_rejected(void)
+{
+    d_isBusy = false;
+    d_busyUntilEnd = false;
+    d_startRet = false; /* firmware rejects the start (e.g. still busy race) */
+    ProtoEmb_TestRun_t in;
+    memset(&in, 0, sizeof(in));
+    memcpy(in.gcodeId, "gc0003", 6);
+    memcpy(in.testDataId, "td0003", 6);
+    TEST_ASSERT_EQUAL_INT(PROTOEMB_RUNTIME_WRITE_DISPOSITION_NACK, ProtoEmb_onWrite_test_run(&in));
+    TEST_ASSERT_EQUAL_INT(0, d_endCount);
+    TEST_ASSERT_EQUAL_INT(1, d_startCount);
+}
+
+void test_m5_onWrite_manual_move_nacks_when_busy(void)
+{
+    d_addMoveRet = false; /* addManualMove rejects while busy */
+    ProtoEmb_Move_t in;
+    memset(&in, 0, sizeof(in));
+    in.g = (ProtoEmb_GCode_E)1;
+    in.x = 10;
+    in.f = 5;
+    TEST_ASSERT_EQUAL_INT(PROTOEMB_RUNTIME_WRITE_DISPOSITION_NACK, ProtoEmb_onWrite_manual_move(&in));
+}
+
 void test_machine_configuration_round_trips_through_bridge(void)
 {
     ProtoEmb_MachineConfiguration_t in;
@@ -289,6 +315,8 @@ int main(void)
     RUN_TEST(test_onWrite_sample_profile_maps_and_forwards);
     RUN_TEST(test_onWrite_test_run_idle_does_not_end);
     RUN_TEST(test_onWrite_test_run_busy_ends_then_starts);
+    RUN_TEST(test_m5_onWrite_test_run_start_nack_when_rejected);
+    RUN_TEST(test_m5_onWrite_manual_move_nacks_when_busy);
     RUN_TEST(test_machine_configuration_round_trips_through_bridge);
     return UNITY_END();
 }

--- a/Firmware/MaDCore/test/test_core/test_app_testManagement.c
+++ b/Firmware/MaDCore/test/test_core/test_app_testManagement.c
@@ -20,6 +20,8 @@
 
 #include <unity.h>
 #include <string.h>
+#include <stddef.h>
+#include <stdbool.h>
 
 #include "app_testManagement.h"
 #include "app_motion.h"
@@ -28,6 +30,9 @@
 #include "app_notification.h"
 #include "IO_SDCard.h"
 #include "HAL_lock.h"
+
+extern void HAL_lock_mock_reset(void);
+extern int _stdio_debug_lock;
 
 /* ====================================================================== *
  * Test doubles — controllable stand-ins for app_testManagement's deps.   *
@@ -143,6 +148,10 @@ uint32_t IO_SDCard_popMultiple(IO_SDCard_channel_E channel, void *buffer, uint32
 
 static void tm_init(void)
 {
+    /* Matrix tests call tm_init many times per RUN_TEST; reset the mock lock
+     * pool so the 8-slot HAL mock never exhausts mid-test. */
+    HAL_lock_mock_reset();
+    _stdio_debug_lock = HAL_lock_create();
     doubles_reset();
     app_testManagement_init(HAL_lock_create());
 }
@@ -353,4 +362,137 @@ void test_app_testManagement_openFailureEndsStart(void)
 
     app_testManagement_run(); /* ENDING → IDLE */
     TEST_ASSERT_FALSE(app_testManagement_isBusy());
+}
+
+/* ====================================================================== *
+ * M5 — lifecycle matrix: start / end / manual across session phases      *
+ * ====================================================================== */
+
+typedef enum
+{
+    M5_PHASE_IDLE = 0,
+    M5_PHASE_PENDING_START,
+    M5_PHASE_RUNNING,
+    M5_PHASE_AFTER_USER_END,
+    M5_PHASE_AFTER_MOTION_ABORT,
+    M5_PHASE_AFTER_SAMPLE_LIMIT,
+    M5_PHASE_AFTER_OPEN_FAIL,
+} m5_phase_E;
+
+static void m5_enter_phase(m5_phase_E phase)
+{
+    tm_init();
+    switch (phase)
+    {
+    case M5_PHASE_IDLE:
+        break;
+    case M5_PHASE_PENDING_START:
+        TEST_ASSERT_TRUE(app_testManagement_triggerTestStart("pend01"));
+        break;
+    case M5_PHASE_RUNNING:
+        tm_driveToRunning();
+        break;
+    case M5_PHASE_AFTER_USER_END:
+        tm_driveToRunning();
+        TEST_ASSERT_TRUE(app_testManagement_triggerTestEnd());
+        app_testManagement_run(); /* RUNNING → ENDING */
+        app_testManagement_run(); /* ENDING → IDLE */
+        break;
+    case M5_PHASE_AFTER_MOTION_ABORT:
+        tm_driveToRunning();
+        d_motionEnabled = false;
+        app_testManagement_run();
+        app_testManagement_run(); /* ENDING → IDLE */
+        d_motionEnabled = true;
+        break;
+    case M5_PHASE_AFTER_SAMPLE_LIMIT:
+        tm_driveToRunning();
+        d_forceExceeded = true;
+        app_testManagement_run();
+        app_testManagement_run();
+        d_forceExceeded = false;
+        break;
+    case M5_PHASE_AFTER_OPEN_FAIL:
+        TEST_ASSERT_TRUE(app_testManagement_triggerTestStart("nofile"));
+        app_testManagement_run();
+        d_sdLastOpenFailed = true;
+        app_testManagement_run();
+        app_testManagement_run();
+        d_sdLastOpenFailed = false;
+        break;
+    default:
+        break;
+    }
+}
+
+void test_m5_lifecycle_start_manual_matrix(void)
+{
+    /* Columns: phase → expectStartAccepted, expectManualAccepted, expectBusy */
+    typedef struct
+    {
+        m5_phase_E phase;
+        bool startOk;
+        bool manualOk;
+        bool busy;
+    } cell_t;
+
+    static const cell_t cells[] = {
+        {M5_PHASE_IDLE, true, true, false},
+        {M5_PHASE_PENDING_START, false, false, true},
+        {M5_PHASE_RUNNING, false, false, true},
+        {M5_PHASE_AFTER_USER_END, true, true, false},
+        {M5_PHASE_AFTER_MOTION_ABORT, true, true, false},
+        {M5_PHASE_AFTER_SAMPLE_LIMIT, true, true, false},
+        {M5_PHASE_AFTER_OPEN_FAIL, true, true, false},
+    };
+
+    const app_motion_move_t move = { .g = (uint8_t)G0_RAPID_MOVE, .x = 1, .f = 1, .p = 0 };
+
+    for (size_t i = 0; i < sizeof(cells) / sizeof(cells[0]); i++)
+    {
+        const cell_t *c = &cells[i];
+        m5_enter_phase(c->phase);
+
+        TEST_ASSERT_EQUAL_INT(c->busy ? 1 : 0, app_testManagement_isBusy() ? 1 : 0);
+
+        if (c->manualOk)
+        {
+            TEST_ASSERT_TRUE(app_testManagement_addManualMove(&move));
+        }
+        else
+        {
+            TEST_ASSERT_FALSE(app_testManagement_addManualMove(&move));
+        }
+
+        /* Fresh start attempt after the phase is established. */
+        const bool started = app_testManagement_triggerTestStart("mtx001");
+        if (c->startOk)
+        {
+            TEST_ASSERT_TRUE(started);
+            TEST_ASSERT_TRUE(app_testManagement_isBusy());
+        }
+        else
+        {
+            TEST_ASSERT_FALSE(started);
+        }
+    }
+}
+
+/* After any terminal path, a full restart must reach RUNNING. */
+void test_m5_restart_reaches_running_after_each_terminal(void)
+{
+    static const m5_phase_E terminals[] = {
+        M5_PHASE_AFTER_USER_END,
+        M5_PHASE_AFTER_MOTION_ABORT,
+        M5_PHASE_AFTER_SAMPLE_LIMIT,
+        M5_PHASE_AFTER_OPEN_FAIL,
+    };
+    for (size_t i = 0; i < sizeof(terminals) / sizeof(terminals[0]); i++)
+    {
+        m5_enter_phase(terminals[i]);
+        TEST_ASSERT_FALSE(app_testManagement_isBusy());
+        tm_driveToRunning();
+        TEST_ASSERT_TRUE(app_testManagement_isRunning());
+        TEST_ASSERT_TRUE(app_testManagement_isBusy());
+    }
 }

--- a/Firmware/MaDCore/test/test_core/test_main.c
+++ b/Firmware/MaDCore/test/test_core/test_main.c
@@ -28,6 +28,8 @@ extern void test_app_testManagement_userEndStopsRun(void);
 extern void test_app_testManagement_motionDisabledAbortsRun(void);
 extern void test_app_testManagement_sampleLimitAbortsRun(void);
 extern void test_app_testManagement_openFailureEndsStart(void);
+extern void test_m5_lifecycle_start_manual_matrix(void);
+extern void test_m5_restart_reaches_running_after_each_terminal(void);
 extern void HAL_lock_mock_reset(void);
 extern int _stdio_debug_lock; /* defined in shared test/mock_propeller2.c */
 extern dev_nvram_config_t dev_nvram_config;
@@ -81,6 +83,8 @@ void process()
     RUN_TEST(test_app_testManagement_motionDisabledAbortsRun);
     RUN_TEST(test_app_testManagement_sampleLimitAbortsRun);
     RUN_TEST(test_app_testManagement_openFailureEndsStart);
+    RUN_TEST(test_m5_lifecycle_start_manual_matrix);
+    RUN_TEST(test_m5_restart_reaches_running_after_each_terminal);
     UNITY_END();
 }
 

--- a/Software/MaDWasmControl/src/device/DeviceSession.worker.ts
+++ b/Software/MaDWasmControl/src/device/DeviceSession.worker.ts
@@ -73,6 +73,15 @@ import {
   RunTestParams,
   RunTestResult,
 } from './events';
+import {
+  ABORT_ERROR_MESSAGE,
+  DOWNLOAD_RETRY_DELAY_MS,
+  downloadChunkIsTerminal,
+  shouldInvalidatePartialUpload,
+  shouldRetryDownloadNack,
+  shouldRetryUpload,
+  UPLOAD_DEFAULT_MAX_RETRIES,
+} from './sessionPolicy';
 
 /** Poll cadence (ms). Faster than the sample period so reads/writes drain promptly. */
 const TICK_MS = 4;
@@ -410,8 +419,8 @@ class DeviceSession {
     let pending: Uint8Array[] = [];
     const flushMoves = async () => {
       for (const batch of batchMoveBuffers(pending, BATCH_MOVE_COUNT)) {
-        if (this.aborting) throw new Error('aborted by emergency stop');
-        await this.uploadWithRetry(MSG_WRITE_TEST_MOVE, batch, 3);
+        if (this.aborting) throw new Error(ABORT_ERROR_MESSAGE);
+        await this.uploadWithRetry(MSG_WRITE_TEST_MOVE, batch, UPLOAD_DEFAULT_MAX_RETRIES);
       }
       pending = [];
     };
@@ -420,8 +429,8 @@ class DeviceSession {
         pending.push(op.buf);
       } else {
         await flushMoves(); // preserve program order before the waveform
-        if (this.aborting) throw new Error('aborted by emergency stop');
-        await this.uploadWithRetry(MSG_WRITE_TEST_WAVEFORM, op.buf, 3);
+        if (this.aborting) throw new Error(ABORT_ERROR_MESSAGE);
+        await this.uploadWithRetry(MSG_WRITE_TEST_WAVEFORM, op.buf, UPLOAD_DEFAULT_MAX_RETRIES);
       }
     }
     await flushMoves();
@@ -444,7 +453,7 @@ class DeviceSession {
         });
         const gaugeMm = resolveGaugeLengthMm(gaugeLengthMm, this.lastSample);
         await this.uploadProgram(gcodeLinesToProgram(lines, gaugeMm));
-        if (this.aborting) throw new Error('aborted by emergency stop');
+        if (this.aborting) throw new Error(ABORT_ERROR_MESSAGE);
 
         // 3. Start the test only after the COMPLETE program (incl. trailing G122)
         //    is uploaded. Build the payload via the generated codec, not by hand.
@@ -456,10 +465,12 @@ class DeviceSession {
         // Invalidate any partially-written SD file: re-opening for WRITE truncates
         // it (firmware "wb"), so a half-uploaded program can never later run to EOF
         // and report a false "complete". Best-effort.
-        try {
-          this.client?.write(MSG_WRITE_TEST_MOVE, openId);
-        } catch {
-          /* ignore */
+        if (shouldInvalidatePartialUpload(false)) {
+          try {
+            this.client?.write(MSG_WRITE_TEST_MOVE, openId);
+          } catch {
+            /* ignore */
+          }
         }
         return {
           success: false,
@@ -495,9 +506,6 @@ class DeviceSession {
     onProgress?: (p: FileDownloadProgress) => void,
   ): Promise<DownloadResult> {
     const SAMPLES_PER_REQUEST = 100;
-    const MAX_NOT_READY_RETRIES = 80;
-    const MAX_MID_RETRIES = 20;
-    const NOT_READY_RETRY_DELAY_MS = 100;
 
     return this.runOp(async () => {
     this.aborting = false;
@@ -508,7 +516,7 @@ class DeviceSession {
       let done = false;
 
       while (!done) {
-        if (this.aborting) throw new Error('aborted by emergency stop');
+        if (this.aborting) throw new Error(ABORT_ERROR_MESSAGE);
         const request = new Uint8Array(24);
         request.set(asciiBytes(testName, 16), 0);
         const view = new DataView(request.buffer);
@@ -526,11 +534,10 @@ class DeviceSession {
             // on the first chunk, so a mid-stream BUSY (e.g. the SD card still
             // flushing right after a test) doesn't discard everything already
             // downloaded. The first chunk waits longer (file may not exist yet).
-            const cap = sampleIndex === 0 ? MAX_NOT_READY_RETRIES : MAX_MID_RETRIES;
-            if (notReadyRetries < cap) {
+            if (shouldRetryDownloadNack(notReadyRetries, sampleIndex)) {
               notReadyRetries += 1;
                
-              await delay(NOT_READY_RETRY_DELAY_MS);
+              await delay(DOWNLOAD_RETRY_DELAY_MS);
               continue;
             }
             throw new Error('Test data not ready');
@@ -538,7 +545,18 @@ class DeviceSession {
           chunk = next.chunk;
         }
 
-        if (chunk.length === 0) {
+        if (downloadChunkIsTerminal(chunk.length, SAMPLES_PER_REQUEST, STOREDSAMPLE_WIRE_SIZE)) {
+          if (chunk.length > 0) {
+            chunks.push(chunk);
+            downloadedBytes += chunk.length;
+            sampleIndex += Math.floor(chunk.length / STOREDSAMPLE_WIRE_SIZE);
+            onProgress?.({
+              fileName: testName,
+              bytesDownloaded: downloadedBytes,
+              totalBytes: 0,
+              status: 'downloading',
+            });
+          }
           done = true;
         } else {
           chunks.push(chunk);
@@ -551,7 +569,6 @@ class DeviceSession {
             totalBytes: 0,
             status: 'downloading',
           });
-          if (received < SAMPLES_PER_REQUEST) done = true;
         }
       }
 
@@ -738,14 +755,14 @@ class DeviceSession {
   private async uploadWithRetry(command: number, data: Uint8Array, maxRetries: number): Promise<void> {
     let attempt = 0;
     for (;;) {
-      if (this.aborting) throw new Error('aborted by emergency stop');
+      if (this.aborting) throw new Error(ABORT_ERROR_MESSAGE);
       try {
          
         await this.writeAndAckOrThrow(command, data, 5000);
         return;
       } catch (err) {
         attempt += 1;
-        if (attempt >= maxRetries) throw err;
+        if (!shouldRetryUpload(attempt, maxRetries)) throw err;
          
         await delay(1000);
       }

--- a/Software/MaDWasmControl/src/device/sessionPolicy.test.ts
+++ b/Software/MaDWasmControl/src/device/sessionPolicy.test.ts
@@ -1,0 +1,120 @@
+/**
+ * M7 — DeviceSession policy matrix (pure).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  downloadNackRetryCap,
+  shouldRetryDownloadNack,
+  shouldRetryUpload,
+  shouldInvalidatePartialUpload,
+  isAbortError,
+  ABORT_ERROR_MESSAGE,
+  OpMutex,
+  downloadChunkIsTerminal,
+  DOWNLOAD_MAX_NOT_READY_RETRIES,
+  DOWNLOAD_MAX_MID_RETRIES,
+  UPLOAD_DEFAULT_MAX_RETRIES,
+} from './sessionPolicy';
+
+describe('M7 download NACK retry matrix', () => {
+  it.each([
+    { sampleIndex: 0, expectCap: DOWNLOAD_MAX_NOT_READY_RETRIES },
+    { sampleIndex: 1, expectCap: DOWNLOAD_MAX_MID_RETRIES },
+    { sampleIndex: 100, expectCap: DOWNLOAD_MAX_MID_RETRIES },
+  ])('cap at sampleIndex=$sampleIndex is $expectCap', ({ sampleIndex, expectCap }) => {
+    expect(downloadNackRetryCap(sampleIndex)).toBe(expectCap);
+  });
+
+  it.each([
+    { sampleIndex: 0, retries: 0, ok: true },
+    { sampleIndex: 0, retries: DOWNLOAD_MAX_NOT_READY_RETRIES - 1, ok: true },
+    { sampleIndex: 0, retries: DOWNLOAD_MAX_NOT_READY_RETRIES, ok: false },
+    { sampleIndex: 5, retries: DOWNLOAD_MAX_MID_RETRIES - 1, ok: true },
+    { sampleIndex: 5, retries: DOWNLOAD_MAX_MID_RETRIES, ok: false },
+  ])(
+    'sampleIndex=$sampleIndex after $retries NACKs → retry=$ok',
+    ({ sampleIndex, retries, ok }) => {
+      expect(shouldRetryDownloadNack(retries, sampleIndex)).toBe(ok);
+    },
+  );
+});
+
+describe('M7 upload retry matrix', () => {
+  it.each([
+    { attempt: 0, max: 3, ok: true },
+    { attempt: 1, max: 3, ok: true },
+    { attempt: 2, max: 3, ok: true },
+    { attempt: 3, max: 3, ok: false },
+    { attempt: 1, max: 1, ok: false },
+  ])('attempt=$attempt max=$max → retry=$ok', ({ attempt, max, ok }) => {
+    expect(shouldRetryUpload(attempt, max)).toBe(ok);
+  });
+
+  it('default max retries is 3', () => {
+    expect(UPLOAD_DEFAULT_MAX_RETRIES).toBe(3);
+  });
+});
+
+describe('M7 partial upload invalidation', () => {
+  it.each([
+    { success: true, invalidate: false },
+    { success: false, invalidate: true },
+  ])('runSucceeded=$success → invalidate=$invalidate', ({ success, invalidate }) => {
+    expect(shouldInvalidatePartialUpload(success)).toBe(invalidate);
+  });
+});
+
+describe('M7 abort detection', () => {
+  it.each([
+    { msg: ABORT_ERROR_MESSAGE, abort: true },
+    { msg: 'aborted: emergency stop', abort: true },
+    { msg: 'device NACKed command 3', abort: false },
+    { msg: 'response timeout', abort: false },
+  ])('$msg → abort=$abort', ({ msg, abort }) => {
+    expect(isAbortError(msg)).toBe(abort);
+  });
+});
+
+describe('M7 download chunk terminal', () => {
+  const WIRE = 16; // STOREDSAMPLE_WIRE_SIZE-like
+  it.each([
+    { len: 0, perReq: 100, terminal: true },
+    { len: 100 * WIRE, perReq: 100, terminal: false },
+    { len: 50 * WIRE, perReq: 100, terminal: true },
+    { len: WIRE, perReq: 100, terminal: true },
+  ])('len=$len perReq=$perReq → terminal=$terminal', ({ len, perReq, terminal }) => {
+    expect(downloadChunkIsTerminal(len, perReq, WIRE)).toBe(terminal);
+  });
+});
+
+describe('M7 OpMutex single-in-flight', () => {
+  it('serializes concurrent ops (second waits for first)', async () => {
+    const mutex = new OpMutex();
+    const order: number[] = [];
+    const slow = mutex.run(async () => {
+      order.push(1);
+      await new Promise((r) => setTimeout(r, 30));
+      order.push(2);
+      return 'a';
+    });
+    const fast = mutex.run(async () => {
+      order.push(3);
+      return 'b';
+    });
+    const [a, b] = await Promise.all([slow, fast]);
+    expect(a).toBe('a');
+    expect(b).toBe('b');
+    // 1 then 2 complete before 3 starts
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  it('a rejected op does not stall the chain', async () => {
+    const mutex = new OpMutex();
+    await expect(
+      mutex.run(async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+    await expect(mutex.run(async () => 'ok')).resolves.toBe('ok');
+  });
+});

--- a/Software/MaDWasmControl/src/device/sessionPolicy.ts
+++ b/Software/MaDWasmControl/src/device/sessionPolicy.ts
@@ -1,0 +1,72 @@
+/**
+ * Pure policy helpers for DeviceSession.worker (M7).
+ *
+ * Kept free of WASM / Comlink so vitest can lock retry/abort/invalidate contracts
+ * without spinning a real worker.
+ */
+
+/** Max NACK retries for download: first chunk waits longer (file may not exist). */
+export const DOWNLOAD_MAX_NOT_READY_RETRIES = 80;
+export const DOWNLOAD_MAX_MID_RETRIES = 20;
+export const DOWNLOAD_RETRY_DELAY_MS = 100;
+export const UPLOAD_DEFAULT_MAX_RETRIES = 3;
+
+/** Retry budget for a download NACK at the given sample index. */
+export function downloadNackRetryCap(sampleIndex: number): number {
+  return sampleIndex === 0 ? DOWNLOAD_MAX_NOT_READY_RETRIES : DOWNLOAD_MAX_MID_RETRIES;
+}
+
+/** Whether another NACK retry is allowed after `notReadyRetries` prior failures. */
+export function shouldRetryDownloadNack(notReadyRetries: number, sampleIndex: number): boolean {
+  return notReadyRetries < downloadNackRetryCap(sampleIndex);
+}
+
+/** Whether an upload attempt may retry after a failure. */
+export function shouldRetryUpload(attempt: number, maxRetries: number): boolean {
+  return attempt < maxRetries;
+}
+
+/**
+ * A failed runTest after a partial SD write must re-open (truncate) the gcode
+ * file so a half-uploaded program cannot later run to EOF as "complete".
+ */
+export function shouldInvalidatePartialUpload(runSucceeded: boolean): boolean {
+  return !runSucceeded;
+}
+
+export const ABORT_ERROR_MESSAGE = 'aborted by emergency stop';
+
+export function isAbortError(message: string): boolean {
+  return message === ABORT_ERROR_MESSAGE || message.startsWith('aborted:');
+}
+
+/**
+ * Serializes async ops (same pattern as DataStore mutex / worker opChain).
+ * Ensures single-in-flight: op B cannot start until A settles.
+ */
+export class OpMutex {
+  private chain: Promise<unknown> = Promise.resolve();
+
+  run<T>(fn: () => Promise<T>): Promise<T> {
+    const next = this.chain.then(fn, fn);
+    this.chain = next.then(
+      () => undefined,
+      () => undefined,
+    );
+    return next;
+  }
+}
+
+/**
+ * Decide if a chunk ends the download stream.
+ * Empty chunk → EOF; short of full request → last partial page.
+ */
+export function downloadChunkIsTerminal(
+  chunkLength: number,
+  samplesPerRequest: number,
+  sampleWireSize: number,
+): boolean {
+  if (chunkLength === 0) return true;
+  const received = Math.floor(chunkLength / sampleWireSize);
+  return received < samplesPerRequest;
+}

--- a/Software/MaDWasmControl/src/store/deviceEventReduce.test.ts
+++ b/Software/MaDWasmControl/src/store/deviceEventReduce.test.ts
@@ -1,0 +1,96 @@
+/**
+ * B4 — pure device-event reduction matrix.
+ */
+import { describe, it, expect } from 'vitest';
+import { reduceDeviceEvent, isResponding } from './deviceEventReduce';
+import type { DeviceEvent } from '@/device/events';
+import { FaultedReason, RestrictedReason, NotificationType } from '@/domain';
+
+const sample = {
+  'Machine Force (N)': 1,
+  'Machine Position (mm)': 2,
+  'Machine Setpoint (mm)': 2,
+  'Sample Force (N)': 0.5,
+  'Sample Position (mm)': 1,
+};
+
+describe('B4 reduceDeviceEvent matrix', () => {
+  it.each([
+    {
+      e: { kind: 'sample', data: sample } as DeviceEvent,
+      expect: { hasSample: true },
+    },
+    {
+      e: {
+        kind: 'state',
+        data: {
+          faultedReason: FaultedReason.NONE,
+          restrictedReason: RestrictedReason.NONE,
+          testRunning: false,
+          motionEnabled: true,
+        },
+      } as DeviceEvent,
+      expect: { hasState: true },
+    },
+    {
+      e: { kind: 'firmwareVersion', data: { version: '1.2.3' } } as DeviceEvent,
+      expect: { firmwareVersion: '1.2.3' },
+    },
+    {
+      e: { kind: 'error', message: 'boom' } as DeviceEvent,
+      expect: { errorToast: 'Device error: boom', counters: ['device-error'] },
+    },
+    {
+      e: { kind: 'timeout' } as DeviceEvent,
+      expect: { counters: ['timeout'] },
+    },
+    {
+      e: { kind: 'ack', command: 3, success: false } as DeviceEvent,
+      expect: { counters: ['nack'] },
+    },
+    {
+      e: { kind: 'ack', command: 3, success: true } as DeviceEvent,
+      expect: { counters: undefined },
+    },
+    {
+      e: {
+        kind: 'notification',
+        data: { Type: NotificationType.WARN, Message: 'hi' },
+      } as DeviceEvent,
+      expect: { notification: true },
+    },
+  ])('$e.kind patch', ({ e, expect: exp }) => {
+    const p = reduceDeviceEvent(e, false);
+    if (exp.hasSample) expect(p.sample).toEqual(sample);
+    if (exp.hasState) expect(p.machineState?.motionEnabled).toBe(true);
+    if (exp.firmwareVersion) expect(p.firmwareVersion).toBe(exp.firmwareVersion);
+    if (exp.errorToast) expect(p.errorToast).toBe(exp.errorToast);
+    if (exp.counters) expect(p.counters).toEqual(exp.counters);
+    if (exp.counters === undefined && e.kind === 'ack') expect(p.counters).toBeUndefined();
+    if (exp.notification) expect(p.notification?.Message).toBe('hi');
+  });
+
+  it('unexpected disconnect clears machineState and flags unexpected', () => {
+    const p = reduceDeviceEvent({ kind: 'disconnected', reason: 'unplug' }, false);
+    expect(p.machineState).toBeNull();
+    expect(p.disconnect).toEqual({ reason: 'unplug', unexpected: true });
+  });
+
+  it('user disconnect is not unexpected', () => {
+    const p = reduceDeviceEvent({ kind: 'disconnected' }, true);
+    expect(p.disconnect?.unexpected).toBe(false);
+  });
+});
+
+describe('B4 isResponding matrix', () => {
+  const T = 2000;
+  it.each([
+    { now: 5000, last: 0, ok: false },
+    { now: 5000, last: 4000, ok: true }, // 1000 < 2000
+    { now: 5000, last: 3000, ok: false }, // 2000 not < 2000
+    { now: 5000, last: 2999, ok: false },
+    { now: 5000, last: 4500, ok: true },
+  ])('now=$now last=$last → $ok', ({ now, last, ok }) => {
+    expect(isResponding(now, last, T)).toBe(ok);
+  });
+});

--- a/Software/MaDWasmControl/src/store/deviceEventReduce.ts
+++ b/Software/MaDWasmControl/src/store/deviceEventReduce.ts
@@ -1,0 +1,77 @@
+/**
+ * Pure device-event → store-patch reduction (Sprint B4).
+ *
+ * Extracted from useStore's subscribe handler so event contracts can be unit-
+ * tested without Zustand / timers / DeviceClient.
+ */
+
+import type { DeviceEvent } from '@/device/events';
+import type { MachineConfiguration, MachineState, SampleData, SampleProfile } from '@/domain';
+
+export type DeviceEventPatch = {
+  machineState?: MachineState | null;
+  config?: MachineConfiguration | null;
+  sampleProfile?: SampleProfile | null;
+  firmwareVersion?: string | null;
+  /** Sample arrived — caller updates lastSampleAt / liveBuffer. */
+  sample?: SampleData;
+  /** Throttled error toast message (undefined = no toast). */
+  errorToast?: string;
+  /** Diagnostics counter kinds to bump. */
+  counters?: Array<'connected' | 'device-error' | 'timeout' | 'nack' | 'disconnected'>;
+  /** Disconnect bookkeeping. */
+  disconnect?: { reason?: string; unexpected: boolean };
+  /** Append notification toast from firmware. */
+  notification?: { Type: string; Message: string };
+};
+
+/**
+ * Reduce a single DeviceEvent into a store patch.
+ * @param userDisconnect intentional UI disconnect (no error banner).
+ */
+export function reduceDeviceEvent(e: DeviceEvent, userDisconnect: boolean): DeviceEventPatch {
+  switch (e.kind) {
+    case 'sample':
+      return { sample: e.data };
+    case 'state':
+      return { machineState: e.data };
+    case 'configuration':
+      return { config: e.data };
+    case 'sampleProfile':
+      return { sampleProfile: e.data };
+    case 'firmwareVersion':
+      return { firmwareVersion: e.data.version };
+    case 'connected':
+      return { counters: ['connected'] };
+    case 'error':
+      return {
+        counters: ['device-error'],
+        errorToast: `Device error: ${e.message}`,
+      };
+    case 'timeout':
+      return { counters: ['timeout'] };
+    case 'ack':
+      return e.success ? {} : { counters: ['nack'] };
+    case 'notification':
+      return { notification: { Type: e.data.Type, Message: e.data.Message } };
+    case 'disconnected': {
+      const unexpected = !userDisconnect;
+      return {
+        counters: ['disconnected'],
+        disconnect: { reason: e.reason, unexpected },
+        machineState: null,
+      };
+    }
+    case 'portAvailable':
+    case 'data':
+      return {};
+    default:
+      return {};
+  }
+}
+
+/** Responding iff a sample arrived within the timeout window. */
+export function isResponding(nowMs: number, lastSampleAtMs: number, timeoutMs: number): boolean {
+  if (lastSampleAtMs <= 0) return false;
+  return nowMs - lastSampleAtMs < timeoutMs;
+}

--- a/docs/dev/bug-class-coverage.md
+++ b/docs/dev/bug-class-coverage.md
@@ -21,7 +21,8 @@ they are guarded today. Update it when you add a new class or close a gap.
 
 | Class | Historical incidents | Specific guards | Class guards |
 |-------|----------------------|-----------------|--------------|
-| **Concurrency / lifecycle races** (`isBusy`, pending flags, self-cancel) | `c081e6c8` test_run self-cancel; pending start accepted manual move | `test_app_testManagement_*`; `test_onWrite_test_run_idle_does_not_end` / `_busy_ends_then_starts`; SIL `testmanagement-lifecycle`; WASM e2e `TM-busy-restart`, `TM-manual-gate` | Double-start rejected; manual gated while busy; cancel→restart |
+| **Concurrency / lifecycle races** (`isBusy`, pending flags, self-cancel) | `c081e6c8` test_run self-cancel; pending start accepted manual move | `test_app_testManagement_*`; `test_onWrite_test_run_idle_does_not_end` / `_busy_ends_then_starts`; SIL `testmanagement-lifecycle`; WASM e2e `TM-busy-restart`, `TM-manual-gate` | **M5** phase matrix + restart-after-terminal; messageSlave NACK matrix |
+| **Fault / restriction priority** | first-fault-wins; enable refused while faulted | existing per-fault tests | **M4** each fault alone + enable refuse + adjacent pairs; restriction chain |
 | **Unsigned time / rollover** | `86b657ec` IO_protocol `(now-period)>start` underflow | `test_near_zero_clock_does_not_spurious_timeout`; `test_timeout_survives_uint32_ms_wrap` | `lib_utility_elapsed_gt` + unit tests; `lib_timer` wrap + near-zero tests; protocol/timer use the helper |
 | **Unit scale (×1000 N/mN, mm/µm)** | slope stored as N not mN; SIL 1000× mismatches | SIL `regression-scaling-motion`; WASM `sample.test.ts` | force-gauge mN math units; dashboard unit bounds; codec golden vectors |
 | **Protocol enum / wire drift** | G-code enum-compat OOB hang `6972ec9a`; `FORCE_GAUGE_COMMUNICATION` spelling | `test_enum_compat_*`; `stateLabels.test.ts` proto lockstep | `_Static_assert` + runtime enum equality; badge labels non-empty strings |

--- a/docs/dev/bulletproof-test-plan.md
+++ b/docs/dev/bulletproof-test-plan.md
@@ -13,8 +13,8 @@ are stable references for PRs. See also [bug-class-coverage.md](./bug-class-cove
 
 | Sprint | Theme | Status |
 |--------|--------|--------|
-| **A** | M1 unit scale · M2 move bounds · M12 schema lockstep · e2e smoke | **in progress** |
-| **B** | M4 faults/restrictions · M5 lifecycle · M7 worker ops | pending |
+| **A** | M1 unit scale · M2 move bounds · M12 schema lockstep · e2e smoke | **done** |
+| **B** | M4 faults/restrictions · M5 lifecycle · M7 worker ops · B4 store events | **done** |
 | **C** | M8–M11 motion/force/waveform/link e2e matrices | pending |
 | **D** | PR template, pairwise tooling, nightly soak | pending |
 
@@ -49,10 +49,34 @@ Out-of-range packed fields never encode (bit-wrap).
 
 ---
 
-## Sprint B–D
+## Sprint B (done)
 
-See prior audit: M4/M5 Unity tables, worker fake streams, motion/force e2e
-grids, link-loss moments, culture.
+### B1 — M4 Fault × restriction tables
+
+- `test_app_control.c`: each fault alone + enable refused; adjacent first-fault-wins;
+  each active restriction alone; priority chain; sample restrictions locked inactive
+  (firmware checks currently commented).
+
+### B2 — M5 Lifecycle matrix
+
+- `test_app_testManagement.c`: start/manual/busy matrix across IDLE / pending /
+  RUNNING / after user-end / motion-abort / sample-limit / open-fail; restart
+  after each terminal reaches RUNNING.
+- `test_app_messageSlave.c`: start NACK when rejected; manual NACK when busy.
+
+### B3 — M7 Worker policy (pure)
+
+- `sessionPolicy.ts` + tests: download NACK budgets, upload retries, partial-upload
+  invalidate, abort detection, `OpMutex`, chunk terminal.
+- Worker wired to policy helpers.
+
+### B4 — Device event reduction
+
+- `deviceEventReduce.ts` + matrix tests for store patches + `isResponding`.
+
+## Sprint C–D
+
+Motion/force/waveform/link e2e matrices; CI e2e smoke; PR template culture.
 
 ## Definition of done
 


### PR DESCRIPTION
## Summary

Sprint B of the [bulletproof test plan](docs/dev/bulletproof-test-plan.md).

| ID | What |
|----|------|
| **M4** | Fault × restriction Unity matrices in `app_control` — every fault alone, enable refused while faulted, adjacent first-fault-wins, each active restriction, priority chain, sample restrictions locked inactive (firmware checks still commented) |
| **M5** | Lifecycle matrix in `app_testManagement` — start/manual/busy across IDLE / pending / RUNNING / after each terminal path; restart reaches RUNNING; messageSlave NACK cells |
| **M7** | `sessionPolicy.ts` pure helpers (download NACK budgets, upload retries, partial-upload invalidate, `OpMutex`, abort) + wire into `DeviceSession.worker` |
| **B4** | `deviceEventReduce.ts` pure event→store-patch + `isResponding` matrix |

Also fixes Unity fixtures that exhaust the HAL lock mock when a single test loops many `init()` calls.

## Test plan

- [x] `npm test` — 191 tests (includes M7 + B4)
- [x] Firmware local (no ASan): `app_control` 30/30, `testManagement` M5 12/12, `messageSlave` 14/14
- [ ] CI: `pio test -e native_test`, `wasm-control-ci`

## Next

Sprint C — M8–M11 motion/force/waveform/link e2e matrices + CI smoke when playground is GHA-stable.