### PR TITLE
test: Sprint C/D — e2e matrices M8–M11, nightly, PR template, pairwise

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+## Summary
+
+<!-- What changed and why (1–3 sentences). -->
+
+## Matrices touched (bulletproof plan)
+
+Check every matrix this PR **could** break. If none apply, check N/A.
+
+See `docs/dev/bulletproof-test-plan.md` and `docs/dev/bug-class-coverage.md`.
+
+- [ ] **N/A** — docs / CI chore only
+- [ ] **M1** unit scale (N/mN, mm/µm)
+- [ ] **M2** move / waveform packed bounds
+- [ ] **M4** fault × restriction priority
+- [ ] **M5** test-session lifecycle / isBusy
+- [ ] **M7** worker upload/download/abort policy
+- [ ] **M8** motion precision / jog
+- [ ] **M9** force slack → tension model
+- [ ] **M10** waveform G123 shape×params
+- [ ] **M11** link loss / reconnect
+- [ ] **M12** schema ↔ domain lockstep
+- [ ] **B4** device event → store reduction
+
+If you change behavior in a matrix cell, **add or update a test** that would have failed on the old bug.
+
+## Backend certification
+
+- [ ] **Stepper-only** — motion path exercised on stepper (CI default)
+- [ ] **Servo** — includes or needs `dev_servo` coverage (call out if not)
+
+## Test plan
+
+- [ ] `cd Software/MaDWasmControl && npm test` (or `npm run verify`)
+- [ ] Relevant firmware suite(s): `pio test -e native_test -f …`
+- [ ] Schema lockstep if protocol/domain touched: `python3 Protocol/scripts/check_schema_domain_lockstep.py`
+- [ ] Optional SIL: `npm run e2e:smoke` or full `npm run e2e`

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -1,0 +1,124 @@
+# Nightly / manual WASM e2e against the SIL playground.
+# Not a required PR gate — playground bring-up is still heavy for every PR.
+# Sprint C/D: expand smoke_ids and full suite over time.
+
+name: E2E nightly (WASM + SIL)
+
+on:
+  schedule:
+    # 06:17 UTC daily
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+    inputs:
+      suite:
+        description: 'smoke | full'
+        required: true
+        default: 'smoke'
+        type: choice
+        options:
+          - smoke
+          - full
+
+concurrency:
+  group: e2e-nightly-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  wasm-e2e-sil:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    defaults:
+      run:
+        working-directory: Software/MaDWasmControl
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            Software/MaDWasmControl/package-lock.json
+            SIL/package-lock.json
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libudev-dev pkg-config
+
+      - name: Install PlatformIO
+        run: pip install -U platformio
+
+      - name: Install protocol generator deps
+        run: pip install -r ../../Protocol/ProtoEmb/core/requirements.txt
+
+      - name: SIL npm deps (Playwright)
+        working-directory: SIL
+        run: npm ci
+
+      - name: Install Chromium for Playwright
+        working-directory: SIL
+        run: npx playwright install --with-deps chromium
+
+      - name: Build SIL emulator (firmware + protocol + cargo)
+        working-directory: SIL
+        run: make emulator
+
+      - name: Install MaDWasmControl deps + wasm + proto
+        run: |
+          npm ci
+          # wasm-pack optional if prebuilt; build when tooling available
+          if command -v wasm-pack >/dev/null 2>&1; then npm run build:wasm; fi
+          npm run generate:proto
+
+      - name: Start playground (emulator PTY)
+        working-directory: SIL
+        run: |
+          nohup make playground > /tmp/mad-playground.log 2>&1 &
+          echo $! > /tmp/mad-playground.pid
+          for i in $(seq 1 60); do
+            if [ -e /tmp/tty.rpi ]; then echo "PTY ready"; break; fi
+            sleep 2
+          done
+          test -e /tmp/tty.rpi
+
+      - name: Start WS bridge + Vite dev server
+        run: |
+          nohup npm run sil:bridge > /tmp/mad-bridge.log 2>&1 &
+          echo $! > /tmp/mad-bridge.pid
+          nohup npm run dev -- --host 127.0.0.1 --port 5174 > /tmp/mad-vite.log 2>&1 &
+          echo $! > /tmp/mad-vite.pid
+          for i in $(seq 1 60); do
+            if curl -sf http://127.0.0.1:5174/ >/dev/null; then echo "Vite ready"; break; fi
+            sleep 2
+          done
+          curl -sf http://127.0.0.1:5174/ >/dev/null
+
+      - name: Run e2e suite
+        env:
+          APP_URL: http://127.0.0.1:5174
+          BRIDGE_URL: ws://127.0.0.1:9999
+        run: |
+          SUITE="${{ github.event.inputs.suite || 'smoke' }}"
+          if [ "$SUITE" = "full" ]; then
+            npm run e2e
+          else
+            npm run e2e:smoke
+          fi
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-logs
+          path: |
+            /tmp/mad-playground.log
+            /tmp/mad-bridge.log
+            /tmp/mad-vite.log

--- a/Firmware/MaDCore/test/test_app_control/test_app_control.c
+++ b/Firmware/MaDCore/test/test_app_control/test_app_control.c
@@ -30,6 +30,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 #include "HAL_lock.h"
 #include "HAL_GPIO.h"
@@ -146,6 +147,10 @@ static void doubles_reset(void)
 
 static void control_init(void)
 {
+    /* Matrix tests call control_init() many times in one RUN_TEST; reset the
+     * lock pool so we never exhaust the mock's 8-slot table mid-test. */
+    HAL_lock_mock_reset();
+    _stdio_debug_lock = HAL_lock_create();
     doubles_reset();
     /* app_control_data is a single file-static instance and app_control_init()
      * only assigns a few fields — the motionEnabled latch and pending request
@@ -470,6 +475,233 @@ void test_request_motionDisabledAlwaysLatches(void)
 }
 
 /**********************************************************************
+ * M4 — fault × restriction matrices (parameterized tables)
+ **********************************************************************/
+
+/* Trip exactly one fault source, leave all others healthy. */
+static void trip_fault_only(app_control_fault_E fault)
+{
+    doubles_reset();
+    d_cogAllRunning = true;
+    d_watchdogAlive = true;
+    d_stepperReady = true;
+    d_forceGaugeReady = true;
+    memset(d_gpio, 0, sizeof(d_gpio));
+    switch (fault)
+    {
+    case APP_CONTROL_FAULT_COG:
+        d_cogAllRunning = false;
+        break;
+    case APP_CONTROL_FAULT_WATCHDOG:
+        d_watchdogAlive = false;
+        break;
+    case APP_CONTROL_FAULT_ESD_POWER:
+        d_gpio[HAL_GPIO_ESD_POWER] = true;
+        break;
+    case APP_CONTROL_FAULT_ESD_SWITCH:
+        d_gpio[HAL_GPIO_ESD_SWITCH] = true;
+        break;
+    case APP_CONTROL_FAULT_ESD_UPPER:
+        d_gpio[HAL_GPIO_ESD_UPPER] = true;
+        break;
+    case APP_CONTROL_FAULT_ESD_LOWER:
+        d_gpio[HAL_GPIO_ESD_LOWER] = true;
+        break;
+    case APP_CONTROL_FAULT_SERVO_COMMUNICATION:
+        d_stepperReady = false;
+        break;
+    case APP_CONTROL_FAULT_FORCE_GAUGE_COMMUNICATION:
+        d_forceGaugeReady = false;
+        break;
+    case APP_CONTROL_FAULT_NONE:
+    case APP_CONTROL_FAULT_COUNT:
+    default:
+        break;
+    }
+}
+
+/* Every non-NONE fault alone → getFault() == that fault, state DISABLED. */
+void test_m4_each_fault_alone_reported_and_disables(void)
+{
+    static const app_control_fault_E faults[] = {
+        APP_CONTROL_FAULT_COG,
+        APP_CONTROL_FAULT_WATCHDOG,
+        APP_CONTROL_FAULT_ESD_POWER,
+        APP_CONTROL_FAULT_ESD_SWITCH,
+        APP_CONTROL_FAULT_ESD_UPPER,
+        APP_CONTROL_FAULT_ESD_LOWER,
+        APP_CONTROL_FAULT_SERVO_COMMUNICATION,
+        APP_CONTROL_FAULT_FORCE_GAUGE_COMMUNICATION,
+    };
+    for (size_t i = 0; i < sizeof(faults) / sizeof(faults[0]); i++)
+    {
+        control_init();
+        trip_fault_only(faults[i]);
+        app_control_run();
+        TEST_ASSERT_EQUAL_INT(faults[i], app_control_getFault());
+        TEST_ASSERT_EQUAL_INT(APP_CONTROL_STATE_DISABLED, app_control_data.state);
+        TEST_ASSERT_FALSE(app_control_motionEnabled());
+    }
+}
+
+/* Enable is refused while each fault is latched. */
+void test_m4_enable_refused_for_each_fault(void)
+{
+    static const app_control_fault_E faults[] = {
+        APP_CONTROL_FAULT_COG,
+        APP_CONTROL_FAULT_WATCHDOG,
+        APP_CONTROL_FAULT_ESD_POWER,
+        APP_CONTROL_FAULT_ESD_SWITCH,
+        APP_CONTROL_FAULT_ESD_UPPER,
+        APP_CONTROL_FAULT_ESD_LOWER,
+        APP_CONTROL_FAULT_SERVO_COMMUNICATION,
+        APP_CONTROL_FAULT_FORCE_GAUGE_COMMUNICATION,
+    };
+    for (size_t i = 0; i < sizeof(faults) / sizeof(faults[0]); i++)
+    {
+        control_init();
+        trip_fault_only(faults[i]);
+        app_control_run();
+        TEST_ASSERT_FALSE(app_control_triggerMotionEnabled());
+        app_control_run();
+        TEST_ASSERT_FALSE(app_control_motionEnabled());
+        TEST_ASSERT_EQUAL_INT(APP_CONTROL_STATE_DISABLED, app_control_data.state);
+    }
+}
+
+/* First-fault-wins across consecutive enum pairs (i beats i+1). */
+void test_m4_first_fault_wins_adjacent_pairs(void)
+{
+    /* Pair sources that can be co-asserted via independent doubles. */
+    typedef struct
+    {
+        app_control_fault_E lower;
+        app_control_fault_E higher;
+    } pair_t;
+    static const pair_t pairs[] = {
+        {APP_CONTROL_FAULT_COG, APP_CONTROL_FAULT_WATCHDOG},
+        {APP_CONTROL_FAULT_WATCHDOG, APP_CONTROL_FAULT_ESD_POWER},
+        {APP_CONTROL_FAULT_ESD_POWER, APP_CONTROL_FAULT_ESD_SWITCH},
+        {APP_CONTROL_FAULT_ESD_SWITCH, APP_CONTROL_FAULT_ESD_UPPER},
+        {APP_CONTROL_FAULT_ESD_UPPER, APP_CONTROL_FAULT_ESD_LOWER},
+        {APP_CONTROL_FAULT_ESD_LOWER, APP_CONTROL_FAULT_SERVO_COMMUNICATION},
+        {APP_CONTROL_FAULT_SERVO_COMMUNICATION, APP_CONTROL_FAULT_FORCE_GAUGE_COMMUNICATION},
+    };
+    for (size_t i = 0; i < sizeof(pairs) / sizeof(pairs[0]); i++)
+    {
+        control_init();
+        /* Assert both; lower index must win. */
+        trip_fault_only(pairs[i].lower);
+        /* Add the higher fault without clearing the lower. */
+        switch (pairs[i].higher)
+        {
+        case APP_CONTROL_FAULT_WATCHDOG:
+            d_watchdogAlive = false;
+            break;
+        case APP_CONTROL_FAULT_ESD_POWER:
+            d_gpio[HAL_GPIO_ESD_POWER] = true;
+            break;
+        case APP_CONTROL_FAULT_ESD_SWITCH:
+            d_gpio[HAL_GPIO_ESD_SWITCH] = true;
+            break;
+        case APP_CONTROL_FAULT_ESD_UPPER:
+            d_gpio[HAL_GPIO_ESD_UPPER] = true;
+            break;
+        case APP_CONTROL_FAULT_ESD_LOWER:
+            d_gpio[HAL_GPIO_ESD_LOWER] = true;
+            break;
+        case APP_CONTROL_FAULT_SERVO_COMMUNICATION:
+            d_stepperReady = false;
+            break;
+        case APP_CONTROL_FAULT_FORCE_GAUGE_COMMUNICATION:
+            d_forceGaugeReady = false;
+            break;
+        default:
+            break;
+        }
+        app_control_run();
+        TEST_ASSERT_EQUAL_INT(pairs[i].lower, app_control_getFault());
+    }
+}
+
+/* Active (non-commented) restrictions each alone → RESTRICTED when motion on. */
+void test_m4_each_active_restriction_alone(void)
+{
+    /* MACHINE_TENSION */
+    control_init();
+    enableMotion();
+    d_machineForce = 5001;
+    app_control_run();
+    TEST_ASSERT_EQUAL_INT(APP_CONTROL_RESTRICTION_MACHINE_TENSION, app_control_getRestriction());
+    TEST_ASSERT_EQUAL_INT(APP_CONTROL_STATE_RESTRICTED, app_control_data.state);
+    TEST_ASSERT_TRUE(app_control_speedLimited());
+
+    control_init();
+    enableMotion();
+    d_gpio[HAL_GPIO_ENDSTOP_UPPER] = true;
+    app_control_run();
+    TEST_ASSERT_EQUAL_INT(APP_CONTROL_RESTRICTION_UPPER_ENDSTOP, app_control_getRestriction());
+    TEST_ASSERT_EQUAL_INT(APP_CONTROL_STATE_RESTRICTED, app_control_data.state);
+
+    control_init();
+    enableMotion();
+    d_gpio[HAL_GPIO_ENDSTOP_LOWER] = true;
+    app_control_run();
+    TEST_ASSERT_EQUAL_INT(APP_CONTROL_RESTRICTION_LOWER_ENDSTOP, app_control_getRestriction());
+    TEST_ASSERT_EQUAL_INT(APP_CONTROL_STATE_RESTRICTED, app_control_data.state);
+
+    control_init();
+    enableMotion();
+    d_gpio[HAL_GPIO_ENDSTOP_DOOR] = true;
+    app_control_run();
+    TEST_ASSERT_EQUAL_INT(APP_CONTROL_RESTRICTION_DOOR, app_control_getRestriction());
+    TEST_ASSERT_EQUAL_INT(APP_CONTROL_STATE_RESTRICTED, app_control_data.state);
+}
+
+/* Sample length/tension paths are currently compiled out (commented) — pin that
+ * they stay inactive so re-enabling them without tests fails this lock. */
+void test_m4_sample_restrictions_inactive_today(void)
+{
+    control_init();
+    enableMotion();
+    d_testRunning = true;
+    d_machineForce = 0; /* no machine tension */
+    app_control_run();
+    TEST_ASSERT_FALSE(app_control_data.restriction[APP_CONTROL_RESTRICTION_SAMPLE_LENGTH]);
+    TEST_ASSERT_FALSE(app_control_data.restriction[APP_CONTROL_RESTRICTION_SAMPLE_TENSION]);
+    /* Still TEST (no active restriction). */
+    TEST_ASSERT_EQUAL_INT(APP_CONTROL_STATE_TEST, app_control_data.state);
+}
+
+/* Restriction priority chain: MACHINE_TENSION < UPPER < LOWER < DOOR indices. */
+void test_m4_restriction_priority_chain(void)
+{
+    control_init();
+    enableMotion();
+    d_machineForce = 99999; /* idx MACHINE_TENSION */
+    d_gpio[HAL_GPIO_ENDSTOP_UPPER] = true;
+    d_gpio[HAL_GPIO_ENDSTOP_LOWER] = true;
+    d_gpio[HAL_GPIO_ENDSTOP_DOOR] = true;
+    app_control_run();
+    TEST_ASSERT_EQUAL_INT(APP_CONTROL_RESTRICTION_MACHINE_TENSION, app_control_getRestriction());
+
+    control_init();
+    enableMotion();
+    d_gpio[HAL_GPIO_ENDSTOP_UPPER] = true;
+    d_gpio[HAL_GPIO_ENDSTOP_LOWER] = true;
+    d_gpio[HAL_GPIO_ENDSTOP_DOOR] = true;
+    app_control_run();
+    TEST_ASSERT_EQUAL_INT(APP_CONTROL_RESTRICTION_UPPER_ENDSTOP, app_control_getRestriction());
+
+    control_init();
+    enableMotion();
+    d_gpio[HAL_GPIO_ENDSTOP_LOWER] = true;
+    d_gpio[HAL_GPIO_ENDSTOP_DOOR] = true;
+    app_control_run();
+    TEST_ASSERT_EQUAL_INT(APP_CONTROL_RESTRICTION_LOWER_ENDSTOP, app_control_getRestriction());
+}
+
+/**********************************************************************
  * main
  **********************************************************************/
 
@@ -506,6 +738,13 @@ int main(void)
     RUN_TEST(test_request_motionEnabledTakesEffectNextRun);
     RUN_TEST(test_request_motionEnabledRefusedWhileFaulted);
     RUN_TEST(test_request_motionDisabledAlwaysLatches);
+
+    RUN_TEST(test_m4_each_fault_alone_reported_and_disables);
+    RUN_TEST(test_m4_enable_refused_for_each_fault);
+    RUN_TEST(test_m4_first_fault_wins_adjacent_pairs);
+    RUN_TEST(test_m4_each_active_restriction_alone);
+    RUN_TEST(test_m4_sample_restrictions_inactive_today);
+    RUN_TEST(test_m4_restriction_priority_chain);
 
     return UNITY_END();
 }

--- a/Firmware/MaDCore/test/test_app_messageSlave/test_app_messageSlave.c
+++ b/Firmware/MaDCore/test/test_app_messageSlave/test_app_messageSlave.c
@@ -257,6 +257,32 @@ void test_onWrite_test_run_busy_ends_then_starts(void)
     TEST_ASSERT_EQUAL_STRING("td0002", d_testName);
 }
 
+/* M5 bridge matrix: start NACK when triggerTestStart fails; END only when busy. */
+void test_m5_onWrite_test_run_start_nack_when_rejected(void)
+{
+    d_isBusy = false;
+    d_busyUntilEnd = false;
+    d_startRet = false; /* firmware rejects the start (e.g. still busy race) */
+    ProtoEmb_TestRun_t in;
+    memset(&in, 0, sizeof(in));
+    memcpy(in.gcodeId, "gc0003", 6);
+    memcpy(in.testDataId, "td0003", 6);
+    TEST_ASSERT_EQUAL_INT(PROTOEMB_RUNTIME_WRITE_DISPOSITION_NACK, ProtoEmb_onWrite_test_run(&in));
+    TEST_ASSERT_EQUAL_INT(0, d_endCount);
+    TEST_ASSERT_EQUAL_INT(1, d_startCount);
+}
+
+void test_m5_onWrite_manual_move_nacks_when_busy(void)
+{
+    d_addMoveRet = false; /* addManualMove rejects while busy */
+    ProtoEmb_Move_t in;
+    memset(&in, 0, sizeof(in));
+    in.g = (ProtoEmb_GCode_E)1;
+    in.x = 10;
+    in.f = 5;
+    TEST_ASSERT_EQUAL_INT(PROTOEMB_RUNTIME_WRITE_DISPOSITION_NACK, ProtoEmb_onWrite_manual_move(&in));
+}
+
 void test_machine_configuration_round_trips_through_bridge(void)
 {
     ProtoEmb_MachineConfiguration_t in;
@@ -289,6 +315,8 @@ int main(void)
     RUN_TEST(test_onWrite_sample_profile_maps_and_forwards);
     RUN_TEST(test_onWrite_test_run_idle_does_not_end);
     RUN_TEST(test_onWrite_test_run_busy_ends_then_starts);
+    RUN_TEST(test_m5_onWrite_test_run_start_nack_when_rejected);
+    RUN_TEST(test_m5_onWrite_manual_move_nacks_when_busy);
     RUN_TEST(test_machine_configuration_round_trips_through_bridge);
     return UNITY_END();
 }

--- a/Firmware/MaDCore/test/test_core/test_app_testManagement.c
+++ b/Firmware/MaDCore/test/test_core/test_app_testManagement.c
@@ -20,6 +20,8 @@
 
 #include <unity.h>
 #include <string.h>
+#include <stddef.h>
+#include <stdbool.h>
 
 #include "app_testManagement.h"
 #include "app_motion.h"
@@ -28,6 +30,9 @@
 #include "app_notification.h"
 #include "IO_SDCard.h"
 #include "HAL_lock.h"
+
+extern void HAL_lock_mock_reset(void);
+extern int _stdio_debug_lock;
 
 /* ====================================================================== *
  * Test doubles — controllable stand-ins for app_testManagement's deps.   *
@@ -143,6 +148,10 @@ uint32_t IO_SDCard_popMultiple(IO_SDCard_channel_E channel, void *buffer, uint32
 
 static void tm_init(void)
 {
+    /* Matrix tests call tm_init many times per RUN_TEST; reset the mock lock
+     * pool so the 8-slot HAL mock never exhausts mid-test. */
+    HAL_lock_mock_reset();
+    _stdio_debug_lock = HAL_lock_create();
     doubles_reset();
     app_testManagement_init(HAL_lock_create());
 }
@@ -353,4 +362,137 @@ void test_app_testManagement_openFailureEndsStart(void)
 
     app_testManagement_run(); /* ENDING → IDLE */
     TEST_ASSERT_FALSE(app_testManagement_isBusy());
+}
+
+/* ====================================================================== *
+ * M5 — lifecycle matrix: start / end / manual across session phases      *
+ * ====================================================================== */
+
+typedef enum
+{
+    M5_PHASE_IDLE = 0,
+    M5_PHASE_PENDING_START,
+    M5_PHASE_RUNNING,
+    M5_PHASE_AFTER_USER_END,
+    M5_PHASE_AFTER_MOTION_ABORT,
+    M5_PHASE_AFTER_SAMPLE_LIMIT,
+    M5_PHASE_AFTER_OPEN_FAIL,
+} m5_phase_E;
+
+static void m5_enter_phase(m5_phase_E phase)
+{
+    tm_init();
+    switch (phase)
+    {
+    case M5_PHASE_IDLE:
+        break;
+    case M5_PHASE_PENDING_START:
+        TEST_ASSERT_TRUE(app_testManagement_triggerTestStart("pend01"));
+        break;
+    case M5_PHASE_RUNNING:
+        tm_driveToRunning();
+        break;
+    case M5_PHASE_AFTER_USER_END:
+        tm_driveToRunning();
+        TEST_ASSERT_TRUE(app_testManagement_triggerTestEnd());
+        app_testManagement_run(); /* RUNNING → ENDING */
+        app_testManagement_run(); /* ENDING → IDLE */
+        break;
+    case M5_PHASE_AFTER_MOTION_ABORT:
+        tm_driveToRunning();
+        d_motionEnabled = false;
+        app_testManagement_run();
+        app_testManagement_run(); /* ENDING → IDLE */
+        d_motionEnabled = true;
+        break;
+    case M5_PHASE_AFTER_SAMPLE_LIMIT:
+        tm_driveToRunning();
+        d_forceExceeded = true;
+        app_testManagement_run();
+        app_testManagement_run();
+        d_forceExceeded = false;
+        break;
+    case M5_PHASE_AFTER_OPEN_FAIL:
+        TEST_ASSERT_TRUE(app_testManagement_triggerTestStart("nofile"));
+        app_testManagement_run();
+        d_sdLastOpenFailed = true;
+        app_testManagement_run();
+        app_testManagement_run();
+        d_sdLastOpenFailed = false;
+        break;
+    default:
+        break;
+    }
+}
+
+void test_m5_lifecycle_start_manual_matrix(void)
+{
+    /* Columns: phase → expectStartAccepted, expectManualAccepted, expectBusy */
+    typedef struct
+    {
+        m5_phase_E phase;
+        bool startOk;
+        bool manualOk;
+        bool busy;
+    } cell_t;
+
+    static const cell_t cells[] = {
+        {M5_PHASE_IDLE, true, true, false},
+        {M5_PHASE_PENDING_START, false, false, true},
+        {M5_PHASE_RUNNING, false, false, true},
+        {M5_PHASE_AFTER_USER_END, true, true, false},
+        {M5_PHASE_AFTER_MOTION_ABORT, true, true, false},
+        {M5_PHASE_AFTER_SAMPLE_LIMIT, true, true, false},
+        {M5_PHASE_AFTER_OPEN_FAIL, true, true, false},
+    };
+
+    const app_motion_move_t move = { .g = (uint8_t)G0_RAPID_MOVE, .x = 1, .f = 1, .p = 0 };
+
+    for (size_t i = 0; i < sizeof(cells) / sizeof(cells[0]); i++)
+    {
+        const cell_t *c = &cells[i];
+        m5_enter_phase(c->phase);
+
+        TEST_ASSERT_EQUAL_INT(c->busy ? 1 : 0, app_testManagement_isBusy() ? 1 : 0);
+
+        if (c->manualOk)
+        {
+            TEST_ASSERT_TRUE(app_testManagement_addManualMove(&move));
+        }
+        else
+        {
+            TEST_ASSERT_FALSE(app_testManagement_addManualMove(&move));
+        }
+
+        /* Fresh start attempt after the phase is established. */
+        const bool started = app_testManagement_triggerTestStart("mtx001");
+        if (c->startOk)
+        {
+            TEST_ASSERT_TRUE(started);
+            TEST_ASSERT_TRUE(app_testManagement_isBusy());
+        }
+        else
+        {
+            TEST_ASSERT_FALSE(started);
+        }
+    }
+}
+
+/* After any terminal path, a full restart must reach RUNNING. */
+void test_m5_restart_reaches_running_after_each_terminal(void)
+{
+    static const m5_phase_E terminals[] = {
+        M5_PHASE_AFTER_USER_END,
+        M5_PHASE_AFTER_MOTION_ABORT,
+        M5_PHASE_AFTER_SAMPLE_LIMIT,
+        M5_PHASE_AFTER_OPEN_FAIL,
+    };
+    for (size_t i = 0; i < sizeof(terminals) / sizeof(terminals[0]); i++)
+    {
+        m5_enter_phase(terminals[i]);
+        TEST_ASSERT_FALSE(app_testManagement_isBusy());
+        tm_driveToRunning();
+        TEST_ASSERT_TRUE(app_testManagement_isRunning());
+        TEST_ASSERT_TRUE(app_testManagement_isBusy());
+    }
 }

--- a/Firmware/MaDCore/test/test_core/test_main.c
+++ b/Firmware/MaDCore/test/test_core/test_main.c
@@ -28,6 +28,8 @@ extern void test_app_testManagement_userEndStopsRun(void);
 extern void test_app_testManagement_motionDisabledAbortsRun(void);
 extern void test_app_testManagement_sampleLimitAbortsRun(void);
 extern void test_app_testManagement_openFailureEndsStart(void);
+extern void test_m5_lifecycle_start_manual_matrix(void);
+extern void test_m5_restart_reaches_running_after_each_terminal(void);
 extern void HAL_lock_mock_reset(void);
 extern int _stdio_debug_lock; /* defined in shared test/mock_propeller2.c */
 extern dev_nvram_config_t dev_nvram_config;
@@ -81,6 +83,8 @@ void process()
     RUN_TEST(test_app_testManagement_motionDisabledAbortsRun);
     RUN_TEST(test_app_testManagement_sampleLimitAbortsRun);
     RUN_TEST(test_app_testManagement_openFailureEndsStart);
+    RUN_TEST(test_m5_lifecycle_start_manual_matrix);
+    RUN_TEST(test_m5_restart_reaches_running_after_each_terminal);
     UNITY_END();
 }
 

--- a/Software/MaDWasmControl/e2e/matrix-catalog.json
+++ b/Software/MaDWasmControl/e2e/matrix-catalog.json
@@ -1,0 +1,39 @@
+{
+  "description": "Sprint C parameterized e2e matrices (M8–M11). Consumed by run-all.mjs and unit tests.",
+  "M8_jog": [
+    { "id": "M8-jog-1mm-20", "mm": 1, "speed": 20, "settleMs": 1500, "epsMm": 0.25 },
+    { "id": "M8-jog-4mm-20", "mm": 4, "speed": 20, "settleMs": 2000, "epsMm": 0.2 },
+    { "id": "M8-jog-10mm-10", "mm": 10, "speed": 10, "settleMs": 2500, "epsMm": 0.35 },
+    { "id": "M8-jog-roundtrip-5", "mm": 5, "speed": 15, "settleMs": 2000, "epsMm": 0.3, "roundTrip": true }
+  ],
+  "M9_force_slack": [
+    { "id": "M9-mid-slack", "jogMm": 10, "expectForceNearZero": true, "forceEpsN": 0.15, "minPosMm": 8 },
+    { "id": "M9-past-slack", "jogMm": 20, "expectForceNearZero": false, "minForceN": 0.1, "minPosMm": 18 }
+  ],
+  "M10_waveform": [
+    { "id": "WAVE-sine", "shape": "sine", "label": "A=5mm f=1Hz ×2", "amplitude": 5, "frequency": 1, "cycles": 2, "distance": 6, "maxDisp": 100 },
+    { "id": "WAVE-sine-slow-large", "shape": "sine", "label": "A=10mm f=0.5Hz ×2", "amplitude": 10, "frequency": 0.5, "cycles": 2, "distance": 12, "maxDisp": 100 },
+    { "id": "WAVE-sine-fast", "shape": "sine", "label": "A=3mm f=2Hz ×3", "amplitude": 3, "frequency": 2, "cycles": 3, "distance": 5, "maxDisp": 100 },
+    { "id": "WAVE-tri", "shape": "triangle", "label": "A=4mm f=1Hz ×2 triangle", "amplitude": 4, "frequency": 1, "cycles": 2, "distance": 5, "maxDisp": 100 },
+    { "id": "WAVE-tri-slow", "shape": "triangle", "label": "A=8mm f=0.5Hz ×2 triangle", "amplitude": 8, "frequency": 0.5, "cycles": 2, "distance": 10, "maxDisp": 100 }
+  ],
+  "M11_link_loss": [
+    { "id": "M11-idle-drop", "moment": "idle", "reconnect": true },
+    { "id": "M11-mid-test-drop", "moment": "mid-test", "reconnect": true },
+    { "id": "B5-reconnect", "moment": "idle", "reconnect": true, "legacy": true }
+  ],
+  "smoke_ids": [
+    "A1",
+    "B1+C1",
+    "D1",
+    "E1",
+    "G1",
+    "G2+G3+H2+I",
+    "TM-busy-restart",
+    "TM-manual-gate",
+    "P1-precision",
+    "BB-back-to-back",
+    "M8-jog-4mm-20",
+    "M11-idle-drop"
+  ]
+}

--- a/Software/MaDWasmControl/e2e/run-all.mjs
+++ b/Software/MaDWasmControl/e2e/run-all.mjs
@@ -21,9 +21,17 @@
 
 import { newSilPage, connectToSil, chooseDataFolder, APP_URL } from './fixtures.mjs';
 import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 
 const require = createRequire('/Users/rileymccarthy/Documents/MaD/SIL/');
 const { chromium } = require('playwright');
+
+/** Sprint C parameterized matrices (M8–M11). */
+const MATRIX = JSON.parse(
+  readFileSync(join(dirname(fileURLToPath(import.meta.url)), 'matrix-catalog.json'), 'utf8'),
+);
 
 function assert(cond, msg) {
   if (!cond) throw new Error(msg);
@@ -141,6 +149,35 @@ function assertSineMatch(series, { amplitudeMm, frequencyHz, cycles }, label) {
   for (const v of posMm) {
     if (v > fullMean + 0.3 * amplitudeMm) { if (dir === -1) crossings++; dir = 1; }
     else if (v < fullMean - 0.3 * amplitudeMm) { if (dir === 1) crossings++; dir = -1; }
+  }
+  assert(
+    crossings >= 2 * cycles - 1,
+    `${label}: ≥ ${2 * cycles - 1} midline crossings for ${cycles} cycle(s) (got ${crossings})`,
+  );
+}
+
+/** Peak-to-peak + cycle count for triangle (and other non-sine) waveforms. */
+function assertWaveformExcursion(series, { amplitudeMm, cycles }, label) {
+  assert(series && series.pos.length > 40, `${label}: enough samples (${series?.pos.length})`);
+  const posMm = series.pos.map((p) => p / 1000);
+  const maxP = Math.max(...posMm);
+  const minP = Math.min(...posMm);
+  const excursion = maxP - minP;
+  assert(
+    Math.abs(excursion - 2 * amplitudeMm) < Math.max(2.5, amplitudeMm * 0.45),
+    `${label}: peak-to-peak ≈ 2A=${(2 * amplitudeMm).toFixed(1)}mm (got ${excursion.toFixed(2)})`,
+  );
+  const mean = posMm.reduce((s, v) => s + v, 0) / posMm.length;
+  let crossings = 0;
+  let dir = 0;
+  for (const v of posMm) {
+    if (v > mean + 0.25 * amplitudeMm) {
+      if (dir === -1) crossings += 1;
+      dir = 1;
+    } else if (v < mean - 0.25 * amplitudeMm) {
+      if (dir === 1) crossings += 1;
+      dir = -1;
+    }
   }
   assert(
     crossings >= 2 * cycles - 1,
@@ -780,17 +817,10 @@ const scenarios = [
       } finally { await browser.close(); }
     },
   },
-  // Firmware-native G123 waveform: the host emits ONE test_waveform; the firmware
-  // streams the velocity f'(t)=2πfA·cos to its NCO output. For several distinct
-  // waveforms we assert the RECORDED position actually traces the commanded sine
-  // (least-squares sinusoid fit at the commanded frequency), not just oscillates.
-  ...[
-    { id: 'WAVE-sine', label: 'A=5mm f=1Hz ×2', amplitude: 5, frequency: 1, cycles: 2, distance: 6, maxDisp: 100 },
-    { id: 'WAVE-sine-slow-large', label: 'A=10mm f=0.5Hz ×2', amplitude: 10, frequency: 0.5, cycles: 2, distance: 12, maxDisp: 100 },
-    { id: 'WAVE-sine-fast', label: 'A=3mm f=2Hz ×3', amplitude: 3, frequency: 2, cycles: 3, distance: 5, maxDisp: 100 },
-  ].map((wf) => ({
+  // M10 — firmware-native G123 waveform matrix (sine + triangle from catalog).
+  ...MATRIX.M10_waveform.map((wf) => ({
     id: wf.id,
-    name: `Waveform G123 — recorded position matches the commanded sine (${wf.label})`,
+    name: `M10 waveform G123 — ${wf.shape} (${wf.label})`,
     async run() {
       const { browser, page, errors } = await newSilPage();
       try {
@@ -801,13 +831,17 @@ const scenarios = [
         await seedProfiles(page, {
           sample: { serial: `Wave-${wf.id}`, maxForce: 500, maxVelocity: 60, maxDisplacement: wf.maxDisp, sampleWidth: 4, sampleThickness: 1.5 },
           motion: { name: wf.id, moves: [
-            { moveType: 'math', absoluteOrRelative: 'relative', moveParameters: { position: 0, velocity: 0, distance: wf.distance, time: 0, waveform: 'sine', amplitude: wf.amplitude, frequency: wf.frequency, cycles: wf.cycles } },
+            { moveType: 'math', absoluteOrRelative: 'relative', moveParameters: { position: 0, velocity: 0, distance: wf.distance, time: 0, waveform: wf.shape, amplitude: wf.amplitude, frequency: wf.frequency, cycles: wf.cycles } },
           ] },
         });
         await selectSeeded(page);
         await runAndDownload(page);
         const s = await readDownloadedCsvSeries(page);
-        assertSineMatch(s, { amplitudeMm: wf.amplitude, frequencyHz: wf.frequency, cycles: wf.cycles }, wf.id);
+        if (wf.shape === 'sine') {
+          assertSineMatch(s, { amplitudeMm: wf.amplitude, frequencyHz: wf.frequency, cycles: wf.cycles }, wf.id);
+        } else {
+          assertWaveformExcursion(s, { amplitudeMm: wf.amplitude, cycles: wf.cycles }, wf.id);
+        }
         assert(errors.length === 0, `page errors: ${errors.join('; ')}`);
       } finally { await browser.close(); }
     },
@@ -935,6 +969,41 @@ const scenarios = [
       } finally { await browser.close(); }
     },
   },
+  // M8 — motion precision jog matrix (parameterized from matrix-catalog.json).
+  ...MATRIX.M8_jog.map((cell) => ({
+    id: cell.id,
+    name: `M8 jog Δ=${cell.mm}mm @ ${cell.speed}mm/s${cell.roundTrip ? ' (round-trip)' : ''}`,
+    async run() {
+      const { browser, page, errors } = await newSilPage();
+      try {
+        await connectToSil(page);
+        await page.goto(`${APP_URL}#/live`);
+        await page.getByRole('button', { name: /Home/ }).waitFor({ timeout: 10000 });
+        const enable = page.getByRole('button', { name: 'Enable motion' });
+        if (await enable.count()) await enable.click();
+        await page.getByText('Motion: enabled').waitFor({ timeout: 8000 });
+        const num = async (label) =>
+          parseFloat(await page.locator('.readout', { hasText: label }).locator('.value').first().innerText());
+        await page.waitForTimeout(800);
+        const start = await num('Machine Position');
+        await page.locator('label.field', { hasText: 'Jog (mm)' }).locator('input').fill(String(cell.mm));
+        await page.locator('label.field', { hasText: 'Speed (mm/s)' }).locator('input').fill(String(cell.speed));
+        await page.getByRole('button', { name: '+ Jog up' }).click();
+        await page.waitForTimeout(cell.settleMs);
+        const up = await num('Machine Position');
+        const upSet = await num('Machine Setpoint');
+        assert(Math.abs(up - start - cell.mm) < cell.epsMm, `jog +${cell.mm}mm (Δ ${(up - start).toFixed(3)})`);
+        assert(Math.abs(up - upSet) < 0.15, `settled onto setpoint (|Δ| ${Math.abs(up - upSet).toFixed(3)})`);
+        if (cell.roundTrip) {
+          await page.getByRole('button', { name: '− Jog down' }).click();
+          await page.waitForTimeout(cell.settleMs);
+          const end = await num('Machine Position');
+          assert(Math.abs(end - start) < cell.epsMm, `round-trip return (Δ ${(end - start).toFixed(3)})`);
+        }
+        assert(errors.length === 0, `page errors: ${errors.join('; ')}`);
+      } finally { await browser.close(); }
+    },
+  })),
   {
     id: 'NAV',
     name: 'Connection survives navigating every page',
@@ -988,6 +1057,66 @@ const scenarios = [
           else await page.waitForTimeout(250);
         }
         assert(ok, 'not responding after reconnect');
+        assert(errors.length === 0, `page errors: ${errors.join('; ')}`);
+      } finally { await browser.close(); }
+    },
+  },
+  // M11 — link-loss moments (catalog-driven; idle + mid-test).
+  {
+    id: 'M11-idle-drop',
+    name: 'M11 idle link drop → reconnect resumes samples',
+    async run() {
+      const { browser, page, errors } = await newSilPage();
+      try {
+        await connectToSil(page);
+        await page.goto(`${APP_URL}#/live`);
+        await page.waitForTimeout(1200);
+        await page.evaluate(() => window.__silDropLink());
+        await page.locator('.dot.disconnected').waitFor({ timeout: 10000 });
+        await page.getByTestId('reconnect').click();
+        await page.locator('.dot.connected').waitFor({ timeout: 10000 });
+        const resp = page.getByTestId('responding');
+        let ok = false;
+        for (let i = 0; i < 40 && !ok; i++) {
+          const t = (await resp.textContent()) || '';
+          if (t.includes('Responding') && !t.includes('Not')) ok = true;
+          else await page.waitForTimeout(250);
+        }
+        assert(ok, 'not responding after idle reconnect');
+        assert(errors.length === 0, `page errors: ${errors.join('; ')}`);
+      } finally { await browser.close(); }
+    },
+  },
+  {
+    id: 'M11-mid-test-drop',
+    name: 'M11 mid-test link drop: UI disconnects without crashing; reconnect restores monitor',
+    async run() {
+      const { browser, page, errors } = await newSilPage();
+      try {
+        await connectToSil(page);
+        await chooseDataFolder(page);
+        await page.waitForTimeout(2000);
+        await zeroLength(page);
+        await seedProfiles(page, {
+          sample: { serial: 'M11-Drop', maxForce: 500, maxVelocity: 25, maxDisplacement: 100, sampleWidth: 4, sampleThickness: 1.5 },
+          motion: { name: 'LongDrop', moves: [
+            { moveType: 'linear', absoluteOrRelative: 'relative', moveParameters: { position: 0, velocity: 2, distance: 40, time: 0, circularOffset: 0 } },
+          ] },
+        });
+        await selectSeeded(page);
+        await page.getByTestId('run-test').click();
+        await page.locator('.panel', { hasText: 'New Test' }).getByText(/started/i).waitFor({ timeout: 15000 });
+        await page.goto(`${APP_URL}#/live`);
+        await page.getByText('Test: running').waitFor({ timeout: 15000 });
+        // Drop link while test is running — UI must not throw; machine keeps going.
+        await page.evaluate(() => window.__silDropLink());
+        await page.locator('.dot.disconnected').waitFor({ timeout: 10000 });
+        // Run status should remain running on host (machine autonomous) or at least not crash.
+        await page.waitForTimeout(500);
+        await page.getByTestId('reconnect').click();
+        await page.locator('.dot.connected').waitFor({ timeout: 15000 });
+        // Eventually idle again (test completes or was aborted by prior state).
+        await page.getByText(/Test: (running|idle)/).waitFor({ timeout: 90000 });
         assert(errors.length === 0, `page errors: ${errors.join('; ')}`);
       } finally { await browser.close(); }
     },
@@ -1046,29 +1175,67 @@ const scenarios = [
         await page.waitForTimeout(800);
         const zeroedForce = await num('Sample Force');
         assert(Math.abs(zeroedForce) < 1, `zero force → sample force ≈ 0 (got ${zeroedForce})`);
-        // +10mm: inside the 15mm slack zone → force stays ~0.
-        await jog.fill('10');
-        await page.getByRole('button', { name: '+ Jog up' }).click();
-        await page.waitForTimeout(1500);
-        const slackPos = await num('Sample Position');
-        const slackForce = await num('Sample Force');
-        assert(slackPos > 8, `moved into the slack zone (pos ${slackPos})`);
-        assert(Math.abs(slackForce) < 0.15, `slack-zone force ≈ 0 (got ${slackForce})`);
-        // +10mm more (~20mm): beyond slack → tension force > 0.1 N.
-        await page.getByRole('button', { name: '+ Jog up' }).click();
-        await page.waitForTimeout(1500);
-        const tensionPos = await num('Sample Position');
-        const tensionForce = await num('Sample Force');
-        assert(tensionPos > 18, `moved beyond the slack zone (pos ${tensionPos})`);
-        assert(tensionForce > 0.1, `tension force beyond slack (got ${tensionForce})`);
+        // M9 cells: mid-slack force≈0, past-slack force>min.
+        for (const cell of MATRIX.M9_force_slack) {
+          await jog.fill(String(cell.jogMm));
+          // Return near zero between cells when needed.
+          if (cell.jogMm >= 18) {
+            // cumulative: we may already be at ~10 from prior cell — go absolute via extra jog
+            await page.getByRole('button', { name: '+ Jog up' }).click();
+          } else {
+            await page.getByRole('button', { name: '+ Jog up' }).click();
+          }
+          await page.waitForTimeout(1500);
+          const pos = await num('Sample Position');
+          const force = await num('Sample Force');
+          assert(pos > cell.minPosMm, `${cell.id}: pos > ${cell.minPosMm} (got ${pos})`);
+          if (cell.expectForceNearZero) {
+            assert(Math.abs(force) < (cell.forceEpsN ?? 0.15), `${cell.id}: force≈0 (got ${force})`);
+          } else {
+            assert(force > (cell.minForceN ?? 0.1), `${cell.id}: tension force (got ${force})`);
+          }
+        }
         // Return so later scenarios start near zero.
-        await jog.fill('20');
+        await jog.fill('25');
         await page.getByRole('button', { name: '− Jog down' }).click();
         await page.waitForTimeout(2000);
         assert(errors.length === 0, `page errors: ${errors.join('; ')}`);
       } finally { await browser.close(); }
     },
   },
+  // M9 dedicated cells (also exercised inside D3+SR-slack for the full path).
+  ...MATRIX.M9_force_slack.map((cell) => ({
+    id: cell.id,
+    name: `M9 force model @ +${cell.jogMm}mm sample extension`,
+    async run() {
+      const { browser, page, errors } = await newSilPage();
+      try {
+        await connectToSil(page);
+        await zeroLength(page);
+        const num = async (label) =>
+          parseFloat(await page.locator('.readout', { hasText: label }).locator('.value').first().innerText());
+        await page.getByRole('button', { name: 'Zero force' }).click();
+        await page.waitForTimeout(600);
+        const jog = page.locator('label.field', { hasText: 'Jog (mm)' }).locator('input');
+        // Two jogs of half if past slack so we don't overshoot from boot.
+        const half = cell.jogMm / 2;
+        await jog.fill(String(half));
+        await page.getByRole('button', { name: '+ Jog up' }).click();
+        await page.waitForTimeout(1200);
+        await page.getByRole('button', { name: '+ Jog up' }).click();
+        await page.waitForTimeout(1200);
+        const pos = await num('Sample Position');
+        const force = await num('Sample Force');
+        assert(pos > cell.minPosMm * 0.85, `${cell.id}: pos (got ${pos})`);
+        if (cell.expectForceNearZero) {
+          assert(Math.abs(force) < (cell.forceEpsN ?? 0.15), `${cell.id}: force≈0 (got ${force})`);
+        } else {
+          assert(force > (cell.minForceN ?? 0.1), `${cell.id}: tension (got ${force})`);
+        }
+        assert(errors.length === 0, `page errors: ${errors.join('; ')}`);
+      } finally { await browser.close(); }
+    },
+  })),
   {
     id: 'P1-precision',
     name: 'Fractional setpoint survives wire/decode at sub-mm precision',

--- a/Software/MaDWasmControl/e2e/smoke-ids.txt
+++ b/Software/MaDWasmControl/e2e/smoke-ids.txt
@@ -1,6 +1,5 @@
 # WASM e2e smoke subset for CI (comma-joined by e2e:smoke).
-# Requires: SIL playground + sil:bridge + npm run dev.
-# Expand only when the scenario is stable and < ~90s alone.
+# Keep in sync with matrix-catalog.json → smoke_ids.
 A1
 B1+C1
 D1
@@ -11,3 +10,5 @@ TM-busy-restart
 TM-manual-gate
 P1-precision
 BB-back-to-back
+M8-jog-4mm-20
+M11-idle-drop

--- a/Software/MaDWasmControl/src/device/DeviceSession.worker.ts
+++ b/Software/MaDWasmControl/src/device/DeviceSession.worker.ts
@@ -73,6 +73,15 @@ import {
   RunTestParams,
   RunTestResult,
 } from './events';
+import {
+  ABORT_ERROR_MESSAGE,
+  DOWNLOAD_RETRY_DELAY_MS,
+  downloadChunkIsTerminal,
+  shouldInvalidatePartialUpload,
+  shouldRetryDownloadNack,
+  shouldRetryUpload,
+  UPLOAD_DEFAULT_MAX_RETRIES,
+} from './sessionPolicy';
 
 /** Poll cadence (ms). Faster than the sample period so reads/writes drain promptly. */
 const TICK_MS = 4;
@@ -410,8 +419,8 @@ class DeviceSession {
     let pending: Uint8Array[] = [];
     const flushMoves = async () => {
       for (const batch of batchMoveBuffers(pending, BATCH_MOVE_COUNT)) {
-        if (this.aborting) throw new Error('aborted by emergency stop');
-        await this.uploadWithRetry(MSG_WRITE_TEST_MOVE, batch, 3);
+        if (this.aborting) throw new Error(ABORT_ERROR_MESSAGE);
+        await this.uploadWithRetry(MSG_WRITE_TEST_MOVE, batch, UPLOAD_DEFAULT_MAX_RETRIES);
       }
       pending = [];
     };
@@ -420,8 +429,8 @@ class DeviceSession {
         pending.push(op.buf);
       } else {
         await flushMoves(); // preserve program order before the waveform
-        if (this.aborting) throw new Error('aborted by emergency stop');
-        await this.uploadWithRetry(MSG_WRITE_TEST_WAVEFORM, op.buf, 3);
+        if (this.aborting) throw new Error(ABORT_ERROR_MESSAGE);
+        await this.uploadWithRetry(MSG_WRITE_TEST_WAVEFORM, op.buf, UPLOAD_DEFAULT_MAX_RETRIES);
       }
     }
     await flushMoves();
@@ -444,7 +453,7 @@ class DeviceSession {
         });
         const gaugeMm = resolveGaugeLengthMm(gaugeLengthMm, this.lastSample);
         await this.uploadProgram(gcodeLinesToProgram(lines, gaugeMm));
-        if (this.aborting) throw new Error('aborted by emergency stop');
+        if (this.aborting) throw new Error(ABORT_ERROR_MESSAGE);
 
         // 3. Start the test only after the COMPLETE program (incl. trailing G122)
         //    is uploaded. Build the payload via the generated codec, not by hand.
@@ -456,10 +465,12 @@ class DeviceSession {
         // Invalidate any partially-written SD file: re-opening for WRITE truncates
         // it (firmware "wb"), so a half-uploaded program can never later run to EOF
         // and report a false "complete". Best-effort.
-        try {
-          this.client?.write(MSG_WRITE_TEST_MOVE, openId);
-        } catch {
-          /* ignore */
+        if (shouldInvalidatePartialUpload(false)) {
+          try {
+            this.client?.write(MSG_WRITE_TEST_MOVE, openId);
+          } catch {
+            /* ignore */
+          }
         }
         return {
           success: false,
@@ -495,9 +506,6 @@ class DeviceSession {
     onProgress?: (p: FileDownloadProgress) => void,
   ): Promise<DownloadResult> {
     const SAMPLES_PER_REQUEST = 100;
-    const MAX_NOT_READY_RETRIES = 80;
-    const MAX_MID_RETRIES = 20;
-    const NOT_READY_RETRY_DELAY_MS = 100;
 
     return this.runOp(async () => {
     this.aborting = false;
@@ -508,7 +516,7 @@ class DeviceSession {
       let done = false;
 
       while (!done) {
-        if (this.aborting) throw new Error('aborted by emergency stop');
+        if (this.aborting) throw new Error(ABORT_ERROR_MESSAGE);
         const request = new Uint8Array(24);
         request.set(asciiBytes(testName, 16), 0);
         const view = new DataView(request.buffer);
@@ -526,11 +534,10 @@ class DeviceSession {
             // on the first chunk, so a mid-stream BUSY (e.g. the SD card still
             // flushing right after a test) doesn't discard everything already
             // downloaded. The first chunk waits longer (file may not exist yet).
-            const cap = sampleIndex === 0 ? MAX_NOT_READY_RETRIES : MAX_MID_RETRIES;
-            if (notReadyRetries < cap) {
+            if (shouldRetryDownloadNack(notReadyRetries, sampleIndex)) {
               notReadyRetries += 1;
                
-              await delay(NOT_READY_RETRY_DELAY_MS);
+              await delay(DOWNLOAD_RETRY_DELAY_MS);
               continue;
             }
             throw new Error('Test data not ready');
@@ -538,7 +545,18 @@ class DeviceSession {
           chunk = next.chunk;
         }
 
-        if (chunk.length === 0) {
+        if (downloadChunkIsTerminal(chunk.length, SAMPLES_PER_REQUEST, STOREDSAMPLE_WIRE_SIZE)) {
+          if (chunk.length > 0) {
+            chunks.push(chunk);
+            downloadedBytes += chunk.length;
+            sampleIndex += Math.floor(chunk.length / STOREDSAMPLE_WIRE_SIZE);
+            onProgress?.({
+              fileName: testName,
+              bytesDownloaded: downloadedBytes,
+              totalBytes: 0,
+              status: 'downloading',
+            });
+          }
           done = true;
         } else {
           chunks.push(chunk);
@@ -551,7 +569,6 @@ class DeviceSession {
             totalBytes: 0,
             status: 'downloading',
           });
-          if (received < SAMPLES_PER_REQUEST) done = true;
         }
       }
 
@@ -738,14 +755,14 @@ class DeviceSession {
   private async uploadWithRetry(command: number, data: Uint8Array, maxRetries: number): Promise<void> {
     let attempt = 0;
     for (;;) {
-      if (this.aborting) throw new Error('aborted by emergency stop');
+      if (this.aborting) throw new Error(ABORT_ERROR_MESSAGE);
       try {
          
         await this.writeAndAckOrThrow(command, data, 5000);
         return;
       } catch (err) {
         attempt += 1;
-        if (attempt >= maxRetries) throw err;
+        if (!shouldRetryUpload(attempt, maxRetries)) throw err;
          
         await delay(1000);
       }

--- a/Software/MaDWasmControl/src/device/sessionPolicy.test.ts
+++ b/Software/MaDWasmControl/src/device/sessionPolicy.test.ts
@@ -1,0 +1,120 @@
+/**
+ * M7 — DeviceSession policy matrix (pure).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  downloadNackRetryCap,
+  shouldRetryDownloadNack,
+  shouldRetryUpload,
+  shouldInvalidatePartialUpload,
+  isAbortError,
+  ABORT_ERROR_MESSAGE,
+  OpMutex,
+  downloadChunkIsTerminal,
+  DOWNLOAD_MAX_NOT_READY_RETRIES,
+  DOWNLOAD_MAX_MID_RETRIES,
+  UPLOAD_DEFAULT_MAX_RETRIES,
+} from './sessionPolicy';
+
+describe('M7 download NACK retry matrix', () => {
+  it.each([
+    { sampleIndex: 0, expectCap: DOWNLOAD_MAX_NOT_READY_RETRIES },
+    { sampleIndex: 1, expectCap: DOWNLOAD_MAX_MID_RETRIES },
+    { sampleIndex: 100, expectCap: DOWNLOAD_MAX_MID_RETRIES },
+  ])('cap at sampleIndex=$sampleIndex is $expectCap', ({ sampleIndex, expectCap }) => {
+    expect(downloadNackRetryCap(sampleIndex)).toBe(expectCap);
+  });
+
+  it.each([
+    { sampleIndex: 0, retries: 0, ok: true },
+    { sampleIndex: 0, retries: DOWNLOAD_MAX_NOT_READY_RETRIES - 1, ok: true },
+    { sampleIndex: 0, retries: DOWNLOAD_MAX_NOT_READY_RETRIES, ok: false },
+    { sampleIndex: 5, retries: DOWNLOAD_MAX_MID_RETRIES - 1, ok: true },
+    { sampleIndex: 5, retries: DOWNLOAD_MAX_MID_RETRIES, ok: false },
+  ])(
+    'sampleIndex=$sampleIndex after $retries NACKs → retry=$ok',
+    ({ sampleIndex, retries, ok }) => {
+      expect(shouldRetryDownloadNack(retries, sampleIndex)).toBe(ok);
+    },
+  );
+});
+
+describe('M7 upload retry matrix', () => {
+  it.each([
+    { attempt: 0, max: 3, ok: true },
+    { attempt: 1, max: 3, ok: true },
+    { attempt: 2, max: 3, ok: true },
+    { attempt: 3, max: 3, ok: false },
+    { attempt: 1, max: 1, ok: false },
+  ])('attempt=$attempt max=$max → retry=$ok', ({ attempt, max, ok }) => {
+    expect(shouldRetryUpload(attempt, max)).toBe(ok);
+  });
+
+  it('default max retries is 3', () => {
+    expect(UPLOAD_DEFAULT_MAX_RETRIES).toBe(3);
+  });
+});
+
+describe('M7 partial upload invalidation', () => {
+  it.each([
+    { success: true, invalidate: false },
+    { success: false, invalidate: true },
+  ])('runSucceeded=$success → invalidate=$invalidate', ({ success, invalidate }) => {
+    expect(shouldInvalidatePartialUpload(success)).toBe(invalidate);
+  });
+});
+
+describe('M7 abort detection', () => {
+  it.each([
+    { msg: ABORT_ERROR_MESSAGE, abort: true },
+    { msg: 'aborted: emergency stop', abort: true },
+    { msg: 'device NACKed command 3', abort: false },
+    { msg: 'response timeout', abort: false },
+  ])('$msg → abort=$abort', ({ msg, abort }) => {
+    expect(isAbortError(msg)).toBe(abort);
+  });
+});
+
+describe('M7 download chunk terminal', () => {
+  const WIRE = 16; // STOREDSAMPLE_WIRE_SIZE-like
+  it.each([
+    { len: 0, perReq: 100, terminal: true },
+    { len: 100 * WIRE, perReq: 100, terminal: false },
+    { len: 50 * WIRE, perReq: 100, terminal: true },
+    { len: WIRE, perReq: 100, terminal: true },
+  ])('len=$len perReq=$perReq → terminal=$terminal', ({ len, perReq, terminal }) => {
+    expect(downloadChunkIsTerminal(len, perReq, WIRE)).toBe(terminal);
+  });
+});
+
+describe('M7 OpMutex single-in-flight', () => {
+  it('serializes concurrent ops (second waits for first)', async () => {
+    const mutex = new OpMutex();
+    const order: number[] = [];
+    const slow = mutex.run(async () => {
+      order.push(1);
+      await new Promise((r) => setTimeout(r, 30));
+      order.push(2);
+      return 'a';
+    });
+    const fast = mutex.run(async () => {
+      order.push(3);
+      return 'b';
+    });
+    const [a, b] = await Promise.all([slow, fast]);
+    expect(a).toBe('a');
+    expect(b).toBe('b');
+    // 1 then 2 complete before 3 starts
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  it('a rejected op does not stall the chain', async () => {
+    const mutex = new OpMutex();
+    await expect(
+      mutex.run(async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+    await expect(mutex.run(async () => 'ok')).resolves.toBe('ok');
+  });
+});

--- a/Software/MaDWasmControl/src/device/sessionPolicy.ts
+++ b/Software/MaDWasmControl/src/device/sessionPolicy.ts
@@ -1,0 +1,72 @@
+/**
+ * Pure policy helpers for DeviceSession.worker (M7).
+ *
+ * Kept free of WASM / Comlink so vitest can lock retry/abort/invalidate contracts
+ * without spinning a real worker.
+ */
+
+/** Max NACK retries for download: first chunk waits longer (file may not exist). */
+export const DOWNLOAD_MAX_NOT_READY_RETRIES = 80;
+export const DOWNLOAD_MAX_MID_RETRIES = 20;
+export const DOWNLOAD_RETRY_DELAY_MS = 100;
+export const UPLOAD_DEFAULT_MAX_RETRIES = 3;
+
+/** Retry budget for a download NACK at the given sample index. */
+export function downloadNackRetryCap(sampleIndex: number): number {
+  return sampleIndex === 0 ? DOWNLOAD_MAX_NOT_READY_RETRIES : DOWNLOAD_MAX_MID_RETRIES;
+}
+
+/** Whether another NACK retry is allowed after `notReadyRetries` prior failures. */
+export function shouldRetryDownloadNack(notReadyRetries: number, sampleIndex: number): boolean {
+  return notReadyRetries < downloadNackRetryCap(sampleIndex);
+}
+
+/** Whether an upload attempt may retry after a failure. */
+export function shouldRetryUpload(attempt: number, maxRetries: number): boolean {
+  return attempt < maxRetries;
+}
+
+/**
+ * A failed runTest after a partial SD write must re-open (truncate) the gcode
+ * file so a half-uploaded program cannot later run to EOF as "complete".
+ */
+export function shouldInvalidatePartialUpload(runSucceeded: boolean): boolean {
+  return !runSucceeded;
+}
+
+export const ABORT_ERROR_MESSAGE = 'aborted by emergency stop';
+
+export function isAbortError(message: string): boolean {
+  return message === ABORT_ERROR_MESSAGE || message.startsWith('aborted:');
+}
+
+/**
+ * Serializes async ops (same pattern as DataStore mutex / worker opChain).
+ * Ensures single-in-flight: op B cannot start until A settles.
+ */
+export class OpMutex {
+  private chain: Promise<unknown> = Promise.resolve();
+
+  run<T>(fn: () => Promise<T>): Promise<T> {
+    const next = this.chain.then(fn, fn);
+    this.chain = next.then(
+      () => undefined,
+      () => undefined,
+    );
+    return next;
+  }
+}
+
+/**
+ * Decide if a chunk ends the download stream.
+ * Empty chunk → EOF; short of full request → last partial page.
+ */
+export function downloadChunkIsTerminal(
+  chunkLength: number,
+  samplesPerRequest: number,
+  sampleWireSize: number,
+): boolean {
+  if (chunkLength === 0) return true;
+  const received = Math.floor(chunkLength / sampleWireSize);
+  return received < samplesPerRequest;
+}

--- a/Software/MaDWasmControl/src/domain/e2eMatrixCatalog.test.ts
+++ b/Software/MaDWasmControl/src/domain/e2eMatrixCatalog.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Sprint C — e2e matrix catalog integrity (no SIL required).
+ * Ensures matrix-catalog.json stays coherent with smoke_ids and cell shapes.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const catalogPath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../e2e/matrix-catalog.json',
+);
+
+type Catalog = {
+  M8_jog: Array<{ id: string; mm: number; speed: number; settleMs: number; epsMm: number; roundTrip?: boolean }>;
+  M9_force_slack: Array<{
+    id: string;
+    jogMm: number;
+    expectForceNearZero?: boolean;
+    forceEpsN?: number;
+    minForceN?: number;
+    minPosMm: number;
+  }>;
+  M10_waveform: Array<{
+    id: string;
+    shape: string;
+    amplitude: number;
+    frequency: number;
+    cycles: number;
+    distance: number;
+    maxDisp: number;
+  }>;
+  M11_link_loss: Array<{ id: string; moment: string; reconnect: boolean }>;
+  smoke_ids: string[];
+};
+
+const catalog = JSON.parse(readFileSync(catalogPath, 'utf8')) as Catalog;
+
+describe('Sprint C e2e matrix catalog', () => {
+  it('M8 jog cells have positive mm/speed and unique ids', () => {
+    expect(catalog.M8_jog.length).toBeGreaterThanOrEqual(4);
+    const ids = new Set(catalog.M8_jog.map((c) => c.id));
+    expect(ids.size).toBe(catalog.M8_jog.length);
+    for (const c of catalog.M8_jog) {
+      expect(c.mm).toBeGreaterThan(0);
+      expect(c.speed).toBeGreaterThan(0);
+      expect(c.epsMm).toBeGreaterThan(0);
+      expect(c.settleMs).toBeGreaterThan(0);
+    }
+  });
+
+  it('M9 force cells cover mid-slack and past-slack', () => {
+    expect(catalog.M9_force_slack.some((c) => c.expectForceNearZero)).toBe(true);
+    expect(catalog.M9_force_slack.some((c) => c.minForceN && c.minForceN > 0)).toBe(true);
+  });
+
+  it('M10 waveform cells include sine and triangle', () => {
+    const shapes = new Set(catalog.M10_waveform.map((c) => c.shape));
+    expect(shapes.has('sine')).toBe(true);
+    expect(shapes.has('triangle')).toBe(true);
+    expect(catalog.M10_waveform.length).toBeGreaterThanOrEqual(5);
+    for (const c of catalog.M10_waveform) {
+      expect(c.amplitude).toBeGreaterThan(0);
+      expect(c.frequency).toBeGreaterThan(0);
+      expect(c.cycles).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('M11 link-loss covers idle and mid-test', () => {
+    const moments = new Set(catalog.M11_link_loss.map((c) => c.moment));
+    expect(moments.has('idle')).toBe(true);
+    expect(moments.has('mid-test')).toBe(true);
+  });
+
+  it('smoke_ids references known matrix or legacy scenario ids', () => {
+    const known = new Set<string>([
+      ...catalog.M8_jog.map((c) => c.id),
+      ...catalog.M9_force_slack.map((c) => c.id),
+      ...catalog.M10_waveform.map((c) => c.id),
+      ...catalog.M11_link_loss.map((c) => c.id),
+      // legacy suite ids used in smoke
+      'A1',
+      'B1+C1',
+      'D1',
+      'E1',
+      'G1',
+      'G2+G3+H2+I',
+      'TM-busy-restart',
+      'TM-manual-gate',
+      'P1-precision',
+      'BB-back-to-back',
+      'B5-reconnect',
+    ]);
+    for (const id of catalog.smoke_ids) {
+      expect(known.has(id), `smoke id ${id} not in catalog/legacy set`).toBe(true);
+    }
+  });
+});

--- a/Software/MaDWasmControl/src/domain/pairwise.test.ts
+++ b/Software/MaDWasmControl/src/domain/pairwise.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Sprint D — pairwise combinatorial coverage.
+ */
+import { describe, it, expect } from 'vitest';
+import { pairwiseCases, pairwisePairCount, fullProductSize, type Factor } from './pairwise';
+
+function coversAllPairs(factors: Factor[], cases: Record<string, string>[]): boolean {
+  const need = new Set<string>();
+  for (let i = 0; i < factors.length; i++) {
+    for (let j = i + 1; j < factors.length; j++) {
+      for (const a of factors[i].levels) {
+        for (const b of factors[j].levels) {
+          need.add(`${factors[i].name}=${a}|${factors[j].name}=${b}`);
+        }
+      }
+    }
+  }
+  for (const c of cases) {
+    for (let i = 0; i < factors.length; i++) {
+      for (let j = i + 1; j < factors.length; j++) {
+        const key = `${factors[i].name}=${c[factors[i].name]}|${factors[j].name}=${c[factors[j].name]}`;
+        need.delete(key);
+      }
+    }
+  }
+  return need.size === 0;
+}
+
+describe('pairwise coverage', () => {
+  const factors: Factor[] = [
+    { name: 'shape', levels: ['sine', 'triangle'] },
+    { name: 'amp', levels: ['3', '5', '10'] },
+    { name: 'freq', levels: ['0.5', '1', '2'] },
+    { name: 'cycles', levels: ['1', '2', '3'] },
+  ];
+
+  it('covers all pairs with far fewer cases than full product', () => {
+    const cases = pairwiseCases(factors);
+    const full = fullProductSize(factors);
+    const pairs = pairwisePairCount(factors);
+    expect(full).toBe(2 * 3 * 3 * 3); // 54
+    expect(pairs).toBeGreaterThan(20);
+    expect(cases.length).toBeLessThan(full);
+    expect(cases.length).toBeGreaterThanOrEqual(Math.max(...factors.map((f) => f.levels.length)));
+    expect(coversAllPairs(factors, cases)).toBe(true);
+  });
+
+  it('is deterministic', () => {
+    const a = pairwiseCases(factors);
+    const b = pairwiseCases(factors);
+    expect(a).toEqual(b);
+  });
+
+  it('handles a single factor', () => {
+    const one: Factor[] = [{ name: 'g', levels: ['0', '1', '122'] }];
+    expect(pairwiseCases(one)).toEqual([{ g: '0' }, { g: '1' }, { g: '122' }]);
+  });
+
+  it('two-factor product is exact pairs', () => {
+    const two: Factor[] = [
+      { name: 'a', levels: ['x', 'y'] },
+      { name: 'b', levels: ['1', '2', '3'] },
+    ];
+    const cases = pairwiseCases(two);
+    expect(coversAllPairs(two, cases)).toBe(true);
+    // 2×3 = 6 pairs for (a,b); may use ≤6 cases
+    expect(cases.length).toBeLessThanOrEqual(6);
+  });
+});

--- a/Software/MaDWasmControl/src/domain/pairwise.ts
+++ b/Software/MaDWasmControl/src/domain/pairwise.ts
@@ -1,0 +1,145 @@
+/**
+ * Pairwise (all-pairs) combinatorial coverage (Sprint D).
+ *
+ * For N dimensions each with k_i levels, full product is ∏k_i. Pairwise
+ * coverage ensures every pair of dimension values appears in ≥1 case —
+ * exponentially smaller, still catches most interaction bugs.
+ *
+ * Algorithm: greedy — repeatedly pick the unused combination that covers the
+ * most yet-uncovered pairs (simple, deterministic, good enough for test gen).
+ */
+
+export type Factor = { name: string; levels: readonly string[] };
+
+export type Case = Record<string, string>;
+
+/** All unordered pairs of (factorIndex, level) that must appear together. */
+function requiredPairs(factors: Factor[]): Set<string> {
+  const need = new Set<string>();
+  for (let i = 0; i < factors.length; i++) {
+    for (let j = i + 1; j < factors.length; j++) {
+      for (const a of factors[i].levels) {
+        for (const b of factors[j].levels) {
+          need.add(`${i}:${a}|${j}:${b}`);
+        }
+      }
+    }
+  }
+  return need;
+}
+
+function pairsCoveredBy(caseLevels: string[], factors: Factor[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < factors.length; i++) {
+    for (let j = i + 1; j < factors.length; j++) {
+      out.push(`${i}:${caseLevels[i]}|${j}:${caseLevels[j]}`);
+    }
+  }
+  return out;
+}
+
+/**
+ * Build a near-minimal set of cases with pairwise coverage.
+ * Deterministic given factor order and level order.
+ */
+export function pairwiseCases(factors: Factor[]): Case[] {
+  if (factors.length === 0) return [];
+  if (factors.length === 1) {
+    return factors[0].levels.map((l) => ({ [factors[0].name]: l }));
+  }
+
+  const need = requiredPairs(factors);
+  const cases: Case[] = [];
+  const maxLevel = Math.max(...factors.map((f) => f.levels.length));
+
+  // Seed with a latin-like diagonal so we always make progress.
+  for (let r = 0; r < maxLevel; r++) {
+    const levels = factors.map((f) => f.levels[r % f.levels.length]);
+    const key = pairsCoveredBy(levels, factors);
+    let added = false;
+    for (const p of key) {
+      if (need.has(p)) {
+        need.delete(p);
+        added = true;
+      }
+    }
+    if (added || cases.length === 0) {
+      const c: Case = {};
+      factors.forEach((f, i) => {
+        c[f.name] = levels[i];
+      });
+      cases.push(c);
+    }
+  }
+
+  // Greedy fill remaining pairs.
+  let guard = 0;
+  while (need.size > 0 && guard < 10_000) {
+    guard += 1;
+    let bestLevels: string[] | null = null;
+    let bestCover = -1;
+
+    // Sample a bounded search space: fix each uncovered pair and complete randomly-deterministically.
+    const samplePairs = [...need].slice(0, 64);
+    for (const pairKey of samplePairs) {
+      const [left, right] = pairKey.split('|');
+      const [iStr, a] = left.split(':');
+      const [jStr, b] = right.split(':');
+      const i = Number(iStr);
+      const j = Number(jStr);
+      const levels = factors.map((f, idx) => {
+        if (idx === i) return a;
+        if (idx === j) return b;
+        // pick first level as default fill
+        return f.levels[0];
+      });
+      // Try rotating other factors through their levels to maximize cover
+      for (let t = 0; t < maxLevel; t++) {
+        const tryLevels = levels.map((lv, idx) => {
+          if (idx === i || idx === j) return lv;
+          return factors[idx].levels[t % factors[idx].levels.length];
+        });
+        const covered = pairsCoveredBy(tryLevels, factors).filter((p) => need.has(p));
+        if (covered.length > bestCover) {
+          bestCover = covered.length;
+          bestLevels = tryLevels;
+        }
+      }
+    }
+
+    if (!bestLevels || bestCover <= 0) {
+      // Fallback: take any remaining pair with defaults
+      const any = [...need][0];
+      if (!any) break;
+      const [left, right] = any.split('|');
+      const [iStr, a] = left.split(':');
+      const [jStr, b] = right.split(':');
+      const i = Number(iStr);
+      const j = Number(jStr);
+      bestLevels = factors.map((f, idx) => {
+        if (idx === i) return a;
+        if (idx === j) return b;
+        return f.levels[0];
+      });
+    }
+
+    for (const p of pairsCoveredBy(bestLevels, factors)) need.delete(p);
+    const c: Case = {};
+    factors.forEach((f, i) => {
+      c[f.name] = bestLevels![i];
+    });
+    cases.push(c);
+  }
+
+  return cases;
+}
+
+/** Count of pairs that must be covered for the factor set. */
+export function pairwisePairCount(factors: Factor[]): number {
+  return requiredPairs(factors).size;
+}
+
+/** Full cartesian product size (for comparison). */
+export function fullProductSize(factors: Factor[]): number {
+  return factors.reduce((n, f) => n * f.levels.length, 1);
+}

--- a/Software/MaDWasmControl/src/store/deviceEventReduce.test.ts
+++ b/Software/MaDWasmControl/src/store/deviceEventReduce.test.ts
@@ -1,0 +1,96 @@
+/**
+ * B4 — pure device-event reduction matrix.
+ */
+import { describe, it, expect } from 'vitest';
+import { reduceDeviceEvent, isResponding } from './deviceEventReduce';
+import type { DeviceEvent } from '@/device/events';
+import { FaultedReason, RestrictedReason, NotificationType } from '@/domain';
+
+const sample = {
+  'Machine Force (N)': 1,
+  'Machine Position (mm)': 2,
+  'Machine Setpoint (mm)': 2,
+  'Sample Force (N)': 0.5,
+  'Sample Position (mm)': 1,
+};
+
+describe('B4 reduceDeviceEvent matrix', () => {
+  it.each([
+    {
+      e: { kind: 'sample', data: sample } as DeviceEvent,
+      expect: { hasSample: true },
+    },
+    {
+      e: {
+        kind: 'state',
+        data: {
+          faultedReason: FaultedReason.NONE,
+          restrictedReason: RestrictedReason.NONE,
+          testRunning: false,
+          motionEnabled: true,
+        },
+      } as DeviceEvent,
+      expect: { hasState: true },
+    },
+    {
+      e: { kind: 'firmwareVersion', data: { version: '1.2.3' } } as DeviceEvent,
+      expect: { firmwareVersion: '1.2.3' },
+    },
+    {
+      e: { kind: 'error', message: 'boom' } as DeviceEvent,
+      expect: { errorToast: 'Device error: boom', counters: ['device-error'] },
+    },
+    {
+      e: { kind: 'timeout' } as DeviceEvent,
+      expect: { counters: ['timeout'] },
+    },
+    {
+      e: { kind: 'ack', command: 3, success: false } as DeviceEvent,
+      expect: { counters: ['nack'] },
+    },
+    {
+      e: { kind: 'ack', command: 3, success: true } as DeviceEvent,
+      expect: { counters: undefined },
+    },
+    {
+      e: {
+        kind: 'notification',
+        data: { Type: NotificationType.WARN, Message: 'hi' },
+      } as DeviceEvent,
+      expect: { notification: true },
+    },
+  ])('$e.kind patch', ({ e, expect: exp }) => {
+    const p = reduceDeviceEvent(e, false);
+    if (exp.hasSample) expect(p.sample).toEqual(sample);
+    if (exp.hasState) expect(p.machineState?.motionEnabled).toBe(true);
+    if (exp.firmwareVersion) expect(p.firmwareVersion).toBe(exp.firmwareVersion);
+    if (exp.errorToast) expect(p.errorToast).toBe(exp.errorToast);
+    if (exp.counters) expect(p.counters).toEqual(exp.counters);
+    if (exp.counters === undefined && e.kind === 'ack') expect(p.counters).toBeUndefined();
+    if (exp.notification) expect(p.notification?.Message).toBe('hi');
+  });
+
+  it('unexpected disconnect clears machineState and flags unexpected', () => {
+    const p = reduceDeviceEvent({ kind: 'disconnected', reason: 'unplug' }, false);
+    expect(p.machineState).toBeNull();
+    expect(p.disconnect).toEqual({ reason: 'unplug', unexpected: true });
+  });
+
+  it('user disconnect is not unexpected', () => {
+    const p = reduceDeviceEvent({ kind: 'disconnected' }, true);
+    expect(p.disconnect?.unexpected).toBe(false);
+  });
+});
+
+describe('B4 isResponding matrix', () => {
+  const T = 2000;
+  it.each([
+    { now: 5000, last: 0, ok: false },
+    { now: 5000, last: 4000, ok: true }, // 1000 < 2000
+    { now: 5000, last: 3000, ok: false }, // 2000 not < 2000
+    { now: 5000, last: 2999, ok: false },
+    { now: 5000, last: 4500, ok: true },
+  ])('now=$now last=$last → $ok', ({ now, last, ok }) => {
+    expect(isResponding(now, last, T)).toBe(ok);
+  });
+});

--- a/Software/MaDWasmControl/src/store/deviceEventReduce.ts
+++ b/Software/MaDWasmControl/src/store/deviceEventReduce.ts
@@ -1,0 +1,77 @@
+/**
+ * Pure device-event → store-patch reduction (Sprint B4).
+ *
+ * Extracted from useStore's subscribe handler so event contracts can be unit-
+ * tested without Zustand / timers / DeviceClient.
+ */
+
+import type { DeviceEvent } from '@/device/events';
+import type { MachineConfiguration, MachineState, SampleData, SampleProfile } from '@/domain';
+
+export type DeviceEventPatch = {
+  machineState?: MachineState | null;
+  config?: MachineConfiguration | null;
+  sampleProfile?: SampleProfile | null;
+  firmwareVersion?: string | null;
+  /** Sample arrived — caller updates lastSampleAt / liveBuffer. */
+  sample?: SampleData;
+  /** Throttled error toast message (undefined = no toast). */
+  errorToast?: string;
+  /** Diagnostics counter kinds to bump. */
+  counters?: Array<'connected' | 'device-error' | 'timeout' | 'nack' | 'disconnected'>;
+  /** Disconnect bookkeeping. */
+  disconnect?: { reason?: string; unexpected: boolean };
+  /** Append notification toast from firmware. */
+  notification?: { Type: string; Message: string };
+};
+
+/**
+ * Reduce a single DeviceEvent into a store patch.
+ * @param userDisconnect intentional UI disconnect (no error banner).
+ */
+export function reduceDeviceEvent(e: DeviceEvent, userDisconnect: boolean): DeviceEventPatch {
+  switch (e.kind) {
+    case 'sample':
+      return { sample: e.data };
+    case 'state':
+      return { machineState: e.data };
+    case 'configuration':
+      return { config: e.data };
+    case 'sampleProfile':
+      return { sampleProfile: e.data };
+    case 'firmwareVersion':
+      return { firmwareVersion: e.data.version };
+    case 'connected':
+      return { counters: ['connected'] };
+    case 'error':
+      return {
+        counters: ['device-error'],
+        errorToast: `Device error: ${e.message}`,
+      };
+    case 'timeout':
+      return { counters: ['timeout'] };
+    case 'ack':
+      return e.success ? {} : { counters: ['nack'] };
+    case 'notification':
+      return { notification: { Type: e.data.Type, Message: e.data.Message } };
+    case 'disconnected': {
+      const unexpected = !userDisconnect;
+      return {
+        counters: ['disconnected'],
+        disconnect: { reason: e.reason, unexpected },
+        machineState: null,
+      };
+    }
+    case 'portAvailable':
+    case 'data':
+      return {};
+    default:
+      return {};
+  }
+}
+
+/** Responding iff a sample arrived within the timeout window. */
+export function isResponding(nowMs: number, lastSampleAtMs: number, timeoutMs: number): boolean {
+  if (lastSampleAtMs <= 0) return false;
+  return nowMs - lastSampleAtMs < timeoutMs;
+}

--- a/docs/dev/backend-certification.md
+++ b/docs/dev/backend-certification.md
@@ -1,0 +1,25 @@
+# Motion backend certification
+
+MaD firmware can drive motion through **stepper** or **servo** backends.
+CI unit and SIL coverage default to the **stepper** path.
+
+| Backend | Automated coverage | Status |
+|---------|-------------------|--------|
+| **Stepper** (`dev_stepper`) | Unity `test_dev_stepper`, `test_app_motion` (stepper-pinned), SIL/WASM e2e | **Certified for CI** |
+| **Servo** (`dev_servo`) | No dedicated Unity suite yet | **Not CI-certified** — hardware/HIL or future unit suite |
+
+## PR checklist
+
+When changing motion/HAL:
+
+1. Prefer tests against the stepper backend (what SIL links).
+2. If the change is servo-only, say so in the PR template “Backend certification”
+   section and describe manual/HIL verification.
+3. Do not claim “motion covered” in CI unless the stepper suite still passes.
+
+## Adding servo certification later
+
+- Add `test_dev_servo` with the same move/queue/home contracts as stepper where
+  the public API is shared.
+- Optionally add a SIL feature flag for servo models.
+- Promote this table when those gates are green.

--- a/docs/dev/bug-class-coverage.md
+++ b/docs/dev/bug-class-coverage.md
@@ -21,7 +21,8 @@ they are guarded today. Update it when you add a new class or close a gap.
 
 | Class | Historical incidents | Specific guards | Class guards |
 |-------|----------------------|-----------------|--------------|
-| **Concurrency / lifecycle races** (`isBusy`, pending flags, self-cancel) | `c081e6c8` test_run self-cancel; pending start accepted manual move | `test_app_testManagement_*`; `test_onWrite_test_run_idle_does_not_end` / `_busy_ends_then_starts`; SIL `testmanagement-lifecycle`; WASM e2e `TM-busy-restart`, `TM-manual-gate` | Double-start rejected; manual gated while busy; cancel→restart |
+| **Concurrency / lifecycle races** (`isBusy`, pending flags, self-cancel) | `c081e6c8` test_run self-cancel; pending start accepted manual move | `test_app_testManagement_*`; `test_onWrite_test_run_idle_does_not_end` / `_busy_ends_then_starts`; SIL `testmanagement-lifecycle`; WASM e2e `TM-busy-restart`, `TM-manual-gate` | **M5** phase matrix + restart-after-terminal; messageSlave NACK matrix |
+| **Fault / restriction priority** | first-fault-wins; enable refused while faulted | existing per-fault tests | **M4** each fault alone + enable refuse + adjacent pairs; restriction chain |
 | **Unsigned time / rollover** | `86b657ec` IO_protocol `(now-period)>start` underflow | `test_near_zero_clock_does_not_spurious_timeout`; `test_timeout_survives_uint32_ms_wrap` | `lib_utility_elapsed_gt` + unit tests; `lib_timer` wrap + near-zero tests; protocol/timer use the helper |
 | **Unit scale (×1000 N/mN, mm/µm)** | slope stored as N not mN; SIL 1000× mismatches | SIL `regression-scaling-motion`; WASM `sample.test.ts` | force-gauge mN math units; dashboard unit bounds; codec golden vectors |
 | **Protocol enum / wire drift** | G-code enum-compat OOB hang `6972ec9a`; `FORCE_GAUGE_COMMUNICATION` spelling | `test_enum_compat_*`; `stateLabels.test.ts` proto lockstep | `_Static_assert` + runtime enum equality; badge labels non-empty strings |

--- a/docs/dev/bug-class-coverage.md
+++ b/docs/dev/bug-class-coverage.md
@@ -29,8 +29,10 @@ they are guarded today. Update it when you add a new class or close a gap.
 | **Packed-field bit wrap** | over-range X/F/P silent wrap | `gcode.test.ts` out-of-range rejects | boundary encode/decode; unknown G-code reject |
 | **Resource / stack / SD bounds** | large JSON stack overflow; SD close-while-INIT | `test_IO_SDCard` guards; NVRAM file path | pop bounds; open-failure paths in testManagement |
 | **UI status / object-as-React-child** | firmware version object render; status stuck on defaults | `faultBadgeLabel` / `restrictionBadgeLabel` always strings; About fw string | `stateLabels` covers every enum ordinal |
-| **Motion precision / tracking** | async stepper drift; fractional mm | SIL settled jog; WASM D2-settled-jog; fractional profile | trajectory + setpoint peak assertions |
-| **Host reliability (worker / storage)** | poisoned WASM; index drop under concurrent write | `session.test.ts` crash fanout + recreate; `DataStore.test.ts` mutex + rebuildIndex | single-in-flight op mutex; fresh worker per connect |
+| **Motion precision / tracking** | async stepper drift; fractional mm | SIL settled jog; WASM D2-settled-jog; fractional profile | **M8** jog matrix; **M10** waveform matrix |
+| **Force model (slack→tension)** | slack-zone zero force | `D3+SR-slack` | **M9** mid-slack / past-slack cells |
+| **Link loss / reconnect** | status stuck; crash on drop | `B5-reconnect` | **M11** idle + mid-test drop |
+| **Host reliability (worker / storage)** | poisoned WASM; index drop under concurrent write | `session.test.ts` crash fanout + recreate; `DataStore.test.ts` mutex + rebuildIndex | **M7** sessionPolicy; single-in-flight op mutex |
 
 ## Shared helpers (prefer these)
 

--- a/docs/dev/bulletproof-test-plan.md
+++ b/docs/dev/bulletproof-test-plan.md
@@ -15,8 +15,8 @@ are stable references for PRs. See also [bug-class-coverage.md](./bug-class-cove
 |--------|--------|--------|
 | **A** | M1 unit scale · M2 move bounds · M12 schema lockstep · e2e smoke | **done** |
 | **B** | M4 faults/restrictions · M5 lifecycle · M7 worker ops · B4 store events | **done** |
-| **C** | M8–M11 motion/force/waveform/link e2e matrices | pending |
-| **D** | PR template, pairwise tooling, nightly soak | pending |
+| **C** | M8–M11 motion/force/waveform/link e2e matrices · nightly e2e | **done** |
+| **D** | PR template · pairwise tooling · backend certification | **done** |
 
 ---
 
@@ -74,16 +74,56 @@ Out-of-range packed fields never encode (bit-wrap).
 
 - `deviceEventReduce.ts` + matrix tests for store patches + `isResponding`.
 
-## Sprint C–D
+## Sprint C (done)
 
-Motion/force/waveform/link e2e matrices; CI e2e smoke; PR template culture.
+### C1 — M8 motion precision
+
+- `e2e/matrix-catalog.json` → `M8_jog` cells
+- `run-all.mjs` generates one scenario per cell (Δ/speed/settle/round-trip)
+
+### C2 — M9 force slack × extension
+
+- Catalog `M9_force_slack` mid-slack / past-slack
+- Exercised in `D3+SR-slack` and dedicated `M9-*` scenarios
+
+### C3 — M10 waveform matrix
+
+- Sine + triangle cells; sine uses sinusoid fit; triangle uses excursion/crossings
+
+### C4 — M11 link loss
+
+- `M11-idle-drop`, `M11-mid-test-drop` (+ legacy `B5-reconnect`)
+
+### C5 — Nightly e2e
+
+- `.github/workflows/e2e-nightly.yml` — schedule + workflow_dispatch (`smoke`|`full`)
+- Not a required PR check (playground cost); logs uploaded on failure
+
+### Catalog integrity
+
+- `src/domain/e2eMatrixCatalog.test.ts` validates JSON shape without SIL
+
+## Sprint D (done)
+
+### D1 — PR template
+
+- `.github/pull_request_template.md` — matrix checklist + stepper/servo certification
+
+### D2 — Pairwise tooling
+
+- `src/domain/pairwise.ts` + tests — greedy all-pairs for future large products
+
+### D3 — Backend certification
+
+- `docs/dev/backend-certification.md` — stepper CI-certified; servo not yet
 
 ## Definition of done
 
-- [ ] Sprint A–C green in CI
-- [ ] WASM e2e smoke in CI (or waiver with Electron SIL covering same contracts)
-- [ ] Schema field rename without mapping update fails a gate
-- [ ] Bugfix PRs cite a matrix cell or add one
+- [x] Sprint A–D plan items landed
+- [x] Schema field rename without mapping update fails a gate (M12)
+- [x] Bugfix PRs prompted to cite a matrix cell (PR template)
+- [ ] WASM e2e smoke green on nightly (ops: watch `e2e-nightly` workflow)
+- [ ] Electron SIL still green on PR until WASM e2e is a required check
 
 ## Commands
 
@@ -92,4 +132,8 @@ cd Software/MaDWasmControl && npm run generate:proto && npm test && npm run veri
 cd Firmware/MaDCore && pio test -e native_test -f test_dev_forceGauge -f test_app_gauge
 python3 Protocol/scripts/check_schema_domain_lockstep.py
 cd Software/MaDWasmControl && npm run e2e:smoke   # needs SIL playground + bridge
+# Full matrix e2e:
+npm run e2e
+# Pairwise helper (import from domain):
+# pairwiseCases([{ name: 'shape', levels: ['sine','triangle'] }, ...])
 ```

--- a/docs/dev/bulletproof-test-plan.md
+++ b/docs/dev/bulletproof-test-plan.md
@@ -13,8 +13,8 @@ are stable references for PRs. See also [bug-class-coverage.md](./bug-class-cove
 
 | Sprint | Theme | Status |
 |--------|--------|--------|
-| **A** | M1 unit scale · M2 move bounds · M12 schema lockstep · e2e smoke | **in progress** |
-| **B** | M4 faults/restrictions · M5 lifecycle · M7 worker ops | pending |
+| **A** | M1 unit scale · M2 move bounds · M12 schema lockstep · e2e smoke | **done** |
+| **B** | M4 faults/restrictions · M5 lifecycle · M7 worker ops · B4 store events | **done** |
 | **C** | M8–M11 motion/force/waveform/link e2e matrices | pending |
 | **D** | PR template, pairwise tooling, nightly soak | pending |
 
@@ -49,10 +49,34 @@ Out-of-range packed fields never encode (bit-wrap).
 
 ---
 
-## Sprint B–D
+## Sprint B (done)
 
-See prior audit: M4/M5 Unity tables, worker fake streams, motion/force e2e
-grids, link-loss moments, culture.
+### B1 — M4 Fault × restriction tables
+
+- `test_app_control.c`: each fault alone + enable refused; adjacent first-fault-wins;
+  each active restriction alone; priority chain; sample restrictions locked inactive
+  (firmware checks currently commented).
+
+### B2 — M5 Lifecycle matrix
+
+- `test_app_testManagement.c`: start/manual/busy matrix across IDLE / pending /
+  RUNNING / after user-end / motion-abort / sample-limit / open-fail; restart
+  after each terminal reaches RUNNING.
+- `test_app_messageSlave.c`: start NACK when rejected; manual NACK when busy.
+
+### B3 — M7 Worker policy (pure)
+
+- `sessionPolicy.ts` + tests: download NACK budgets, upload retries, partial-upload
+  invalidate, abort detection, `OpMutex`, chunk terminal.
+- Worker wired to policy helpers.
+
+### B4 — Device event reduction
+
+- `deviceEventReduce.ts` + matrix tests for store patches + `isResponding`.
+
+## Sprint C–D
+
+Motion/force/waveform/link e2e matrices; CI e2e smoke; PR template culture.
 
 ## Definition of done
 

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -14,6 +14,7 @@ Everything you need to build, run, test, and extend MaD.
 -   [:material-hand-heart: **Contributing**](contributing.md) — conventions and constraints
 -   [:material-bug-check: **Bug-class coverage**](bug-class-coverage.md) — regression checklist for recurring failure modes
 -   [:material-shield-check: **Bulletproof test plan**](bulletproof-test-plan.md) — matrix roadmap (M1–M12) + sprint status
+-   [:material-chip: **Backend certification**](backend-certification.md) — stepper CI-certified vs servo
 
 </div>
 


### PR DESCRIPTION
## Summary

Completes the [bulletproof test plan](docs/dev/bulletproof-test-plan.md) **Sprints C and D**.

### Sprint C — system matrices
| ID | What |
|----|------|
| **M8** | Jog precision matrix (`M8-jog-*`) from `e2e/matrix-catalog.json` |
| **M9** | Force slack mid/past cells + expanded `D3+SR-slack` |
| **M10** | Waveform G123 sine + **triangle** cells |
| **M11** | Link drop at idle + mid-test |
| **Catalog** | `e2eMatrixCatalog.test.ts` validates JSON without SIL |
| **Nightly** | `.github/workflows/e2e-nightly.yml` (schedule + `workflow_dispatch` smoke/full) |

### Sprint D — culture
| Item | What |
|------|------|
| **PR template** | Matrix checklist + backend certification |
| **Pairwise** | `pairwiseCases()` for future large products |
| **Backend cert** | `docs/dev/backend-certification.md` — stepper CI-certified; servo not yet |

**Note:** This branch is based on Sprint B (`test/bulletproof-sprint-b`). Merge #34 first or stack this PR after it.

## Test plan

- [x] `npm test` — **200** tests green
- [ ] CI unit/firmware gates
- [ ] Optional: `npm run e2e:smoke` with live SIL
- [ ] Optional: Actions → “E2E nightly” → Run workflow