### PR TITLE
test+chore: followups — e2e CI, servo cert, store reduce, sample limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       software: ${{ steps.changes.outputs.software }}
+      electron: ${{ steps.changes.outputs.electron }}
       firmware: ${{ steps.changes.outputs.firmware }}
       hardware: ${{ steps.changes.outputs.hardware }}
       wasm_control: ${{ steps.changes.outputs.wasm_control }}
@@ -48,6 +49,8 @@ jobs:
           filters: |
             software:
               - 'Software/**'
+            electron:
+              - 'Software/MaDControl/**'
             firmware:
               - 'Firmware/**'
             hardware:
@@ -363,10 +366,14 @@ jobs:
 
   build-software:
     needs: changes
-    # Build software for SIL testing when software/firmware changes, or always for software releases
+    # Frozen Electron app (MaDControl). Package only when that tree changes, on
+    # software-v tags, or when the optional legacy SIL e2e is explicitly enabled.
+    # Control (WASM) PRs and firmware-only PRs must not wait on electron-builder.
     if: |
       needs.changes.outputs.is_software_release == 'true' ||
-      (needs.changes.outputs.software == 'true' || needs.changes.outputs.firmware == 'true')
+      needs.changes.outputs.electron == 'true' ||
+      (vars.RUN_LEGACY_SIL_E2E == 'true' &&
+        (needs.changes.outputs.software == 'true' || needs.changes.outputs.firmware == 'true'))
     runs-on: macos-latest-large
     outputs:
       artifact-name: ${{ steps.artifact.outputs.name }}
@@ -388,7 +395,7 @@ jobs:
           # macos-latest-large ships a Homebrew Python whose pip has no RECORD
           # file — `pip install --upgrade pip` then fails uninstall-no-record-file.
           # Install codegen deps only; do not upgrade the runner pip.
-          python3 -m pip install --break-system-packages --ignore-installed pyyaml jinja2
+          python3 -m pip install --break-system-packages --ignore-installed 'setuptools<81' pyyaml jinja2
 
       - name: Install dependencies
         working-directory: Software/MaDControl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,9 +385,10 @@ jobs:
         
       - name: Ensure Python + protocol codegen deps
         run: |
-          python3 -m pip install --upgrade pip setuptools --break-system-packages
-          # `npm run generate:proto` runs generate.py, which imports yaml + jinja2.
-          python3 -m pip install --break-system-packages pyyaml jinja2
+          # macos-latest-large ships a Homebrew Python whose pip has no RECORD
+          # file — `pip install --upgrade pip` then fails uninstall-no-record-file.
+          # Install codegen deps only; do not upgrade the runner pip.
+          python3 -m pip install --break-system-packages --ignore-installed pyyaml jinja2
 
       - name: Install dependencies
         working-directory: Software/MaDControl

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -44,6 +44,9 @@ jobs:
             SIL/package-lock.json
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
       - uses: actions/setup-python@v7
         with:
           python-version: '3.x'
@@ -58,6 +61,9 @@ jobs:
 
       - name: Install protocol generator deps
         run: pip install -r ../../Protocol/ProtoEmb/core/requirements.txt
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: SIL npm deps (Playwright)
         working-directory: SIL
@@ -74,8 +80,7 @@ jobs:
       - name: Install Control deps + wasm + proto
         run: |
           npm ci
-          # wasm-pack optional if prebuilt; build when tooling available
-          if command -v wasm-pack >/dev/null 2>&1; then npm run build:wasm; fi
+          npm run build:wasm
           npm run generate:proto
 
       - name: Start playground (emulator PTY)
@@ -83,11 +88,15 @@ jobs:
         run: |
           nohup make playground > /tmp/mad-playground.log 2>&1 &
           echo $! > /tmp/mad-playground.pid
-          for i in $(seq 1 60); do
-            if [ -e /tmp/tty.rpi ]; then echo "PTY ready"; break; fi
+          for i in $(seq 1 90); do
+            if [ -e /tmp/tty.rpi ]; then echo "PTY ready after ${i}s"; break; fi
             sleep 2
           done
-          test -e /tmp/tty.rpi
+          if [ ! -e /tmp/tty.rpi ]; then
+            echo "=== playground log ==="
+            cat /tmp/mad-playground.log || true
+            exit 1
+          fi
 
       - name: Start WS bridge + Vite dev server
         run: |
@@ -100,6 +109,18 @@ jobs:
             sleep 2
           done
           curl -sf http://127.0.0.1:5174/ >/dev/null
+          for i in $(seq 1 30); do
+            if (echo >/dev/tcp/127.0.0.1/9999) >/dev/null 2>&1; then
+              echo "Bridge port open"
+              break
+            fi
+            sleep 1
+          done
+          (echo >/dev/tcp/127.0.0.1/9999) >/dev/null 2>&1 || {
+            echo "=== bridge log ==="
+            cat /tmp/mad-bridge.log || true
+            exit 1
+          }
 
       - name: Run e2e suite
         env:

--- a/Firmware/MaDCore/platformio.ini
+++ b/Firmware/MaDCore/platformio.ini
@@ -126,3 +126,25 @@ build_flags =
 build_src_filter =
   +<Library/>
   +<HAL/Include/>
+
+; Local/mac verification without AddressSanitizer (ASan aborts on some macOS toolchains).
+; CI Linux keeps [env:native_test] with ASan.
+[env:native_test_noasan]
+extends = env:native_test
+build_unflags =
+  -fsanitize=address
+  -fstack-protector-all
+build_flags =
+  ${env.build_flags}
+  -Isrc/HW/Native
+  -D__EMULATION__
+  -DENABLE_DEBUG_SERIAL=1
+  -DMOUNT_PATH='"./sd"'
+  -DSD_CARD_MOUNT_PATH='"./test/sd/"'
+  -DPROPELLER_NATIVE=0
+  -DPROPELLER_FRAMEWORK=0
+  -DP2LLVM=1
+  -DFLEXCC=2
+  -Wall
+  -g
+  -lm

--- a/Firmware/MaDCore/src/APP/app_control.c
+++ b/Firmware/MaDCore/src/APP/app_control.c
@@ -140,39 +140,13 @@ static app_control_restriction_E app_control_private_processRestrictions(void)
 {
     if (app_control_data.testRunning)
     {
-        /*// Check sample profile limits during test execution
-        int32_t currentForce = app_gauge_getForce(APP_GAUGE_COORD_SAMPLE);
-        int32_t currentPosition = app_gauge_getPosition(APP_GAUGE_COORD_SAMPLE);
-
-        // Convert current force from mN to N for comparison
-        float currentForceN = currentForce / 1000.0f;
-
-        // Check force limits
-        if (currentForceN > app_control_data.sampleProfile.maxForce)
-        {
-            app_control_data.restriction[APP_CONTROL_RESTRICTION_SAMPLE_TENSION] = true;
-        }
-        else if (currentForceN < -app_control_data.sampleProfile.maxForce)
-        {
-            app_control_data.restriction[APP_CONTROL_RESTRICTION_SAMPLE_TENSION] = true;
-        }
-        else
-        {
-            app_control_data.restriction[APP_CONTROL_RESTRICTION_SAMPLE_TENSION] = false;
-        }
-
-        // Check position limits (convert from um to mm)
-        float currentPositionMm = currentPosition / 1000.0f;
-        float maxStretch = app_control_data.sampleProfile.length * (app_control_data.sampleProfile.stretchMax / 100.0f);
-
-        if (currentPositionMm > maxStretch)
-        {
-            app_control_data.restriction[APP_CONTROL_RESTRICTION_SAMPLE_LENGTH] = true;
-        }
-        else
-        {
-            app_control_data.restriction[APP_CONTROL_RESTRICTION_SAMPLE_LENGTH] = false;
-        }*/
+        /* Sample limits live on app_monitor (maxForce mN, maxDisplacement mm).
+         * Mirror its exceeded flags into control restrictions so the state
+         * machine can drop into RESTRICTED and limit speed. */
+        app_control_data.restriction[APP_CONTROL_RESTRICTION_SAMPLE_TENSION] =
+            app_monitor_isForceExceeded();
+        app_control_data.restriction[APP_CONTROL_RESTRICTION_SAMPLE_LENGTH] =
+            app_monitor_isDisplacementExceeded();
     }
     else
     {

--- a/Firmware/MaDCore/test/test_app_control/test_app_control.c
+++ b/Firmware/MaDCore/test/test_app_control/test_app_control.c
@@ -14,8 +14,9 @@
  *   - fault detection + first-fault-wins priority ordering, and the DISABLED
  *     override (a fault forces DISABLED regardless of motionEnabled).
  *   - restriction detection: machine-tension boundary is strictly '>', endstop
- *     / door GPIOs, and first-restriction-wins ordering. Restrictions are only
- *     reflected as RESTRICTED once motion is enabled and there's no fault.
+ *     / door GPIOs, sample force/displacement via app_monitor flags while a
+ *     test is running, and first-restriction-wins ordering. Restrictions are
+ *     only reflected as RESTRICTED once motion is enabled and there's no fault.
  *   - desired-state precedence: fault > !motionEnabled > restriction >
  *     !testRunning(MANUAL) > TEST.
  *   - per-state outputs (motionEnabled / speedLimited).
@@ -59,11 +60,16 @@ extern int _stdio_debug_lock; /* defined in mock_propeller2.c */
 static int32_t d_machineForce; /* app_gauge_getForce(MACHINE) */
 int32_t app_gauge_getForce(app_gauge_coord_E coord)
 {
-    /* Restrictions only ever query the MACHINE frame (the SAMPLE block is
-     * commented out in the module today). */
+    /* Machine tension uses MACHINE frame; sample limits come from app_monitor. */
     TEST_ASSERT_EQUAL_INT(APP_GAUGE_COORD_MACHINE, coord);
     return d_machineForce;
 }
+
+/* --- app_monitor (sample restriction flags) --- */
+static bool d_forceExceeded;
+static bool d_displacementExceeded;
+bool app_monitor_isForceExceeded(void) { return d_forceExceeded; }
+bool app_monitor_isDisplacementExceeded(void) { return d_displacementExceeded; }
 
 /* --- app_testManagement --- */
 static bool d_testRunning; /* app_testManagement_isRunning() */
@@ -129,6 +135,8 @@ static void doubles_reset(void)
 {
     d_machineForce = 0;
     d_testRunning = false;
+    d_forceExceeded = false;
+    d_displacementExceeded = false;
 
     /* No-fault baseline: cogs running, watchdog alive, ESD GPIOs inactive,
      * servo + force gauge ready. */
@@ -658,19 +666,58 @@ void test_m4_each_active_restriction_alone(void)
     TEST_ASSERT_EQUAL_INT(APP_CONTROL_STATE_RESTRICTED, app_control_data.state);
 }
 
-/* Sample length/tension paths are currently compiled out (commented) — pin that
- * they stay inactive so re-enabling them without tests fails this lock. */
-void test_m4_sample_restrictions_inactive_today(void)
+/* Sample restrictions (SAMPLE_LENGTH / SAMPLE_TENSION) active only while a
+ * test is running and app_monitor reports limit exceeded. */
+void test_m4_sample_restrictions_inactive_when_not_running(void)
+{
+    control_init();
+    enableMotion();
+    d_forceExceeded = true;
+    d_displacementExceeded = true;
+    d_testRunning = false;
+    app_control_run();
+    TEST_ASSERT_FALSE(app_control_data.restriction[APP_CONTROL_RESTRICTION_SAMPLE_LENGTH]);
+    TEST_ASSERT_FALSE(app_control_data.restriction[APP_CONTROL_RESTRICTION_SAMPLE_TENSION]);
+    TEST_ASSERT_EQUAL_INT(APP_CONTROL_STATE_MANUAL, app_control_data.state);
+}
+
+void test_m4_sample_tension_restricts_while_test_running(void)
 {
     control_init();
     enableMotion();
     d_testRunning = true;
-    d_machineForce = 0; /* no machine tension */
+    d_machineForce = 0;
+    d_forceExceeded = true;
     app_control_run();
-    TEST_ASSERT_FALSE(app_control_data.restriction[APP_CONTROL_RESTRICTION_SAMPLE_LENGTH]);
-    TEST_ASSERT_FALSE(app_control_data.restriction[APP_CONTROL_RESTRICTION_SAMPLE_TENSION]);
-    /* Still TEST (no active restriction). */
-    TEST_ASSERT_EQUAL_INT(APP_CONTROL_STATE_TEST, app_control_data.state);
+    TEST_ASSERT_TRUE(app_control_data.restriction[APP_CONTROL_RESTRICTION_SAMPLE_TENSION]);
+    TEST_ASSERT_EQUAL_INT(APP_CONTROL_RESTRICTION_SAMPLE_TENSION, app_control_getRestriction());
+    TEST_ASSERT_EQUAL_INT(APP_CONTROL_STATE_RESTRICTED, app_control_data.state);
+    TEST_ASSERT_TRUE(app_control_speedLimited());
+}
+
+void test_m4_sample_length_restricts_while_test_running(void)
+{
+    control_init();
+    enableMotion();
+    d_testRunning = true;
+    d_machineForce = 0;
+    d_displacementExceeded = true;
+    app_control_run();
+    TEST_ASSERT_TRUE(app_control_data.restriction[APP_CONTROL_RESTRICTION_SAMPLE_LENGTH]);
+    /* SAMPLE_LENGTH has lower enum index than SAMPLE_TENSION → wins alone. */
+    TEST_ASSERT_EQUAL_INT(APP_CONTROL_RESTRICTION_SAMPLE_LENGTH, app_control_getRestriction());
+    TEST_ASSERT_EQUAL_INT(APP_CONTROL_STATE_RESTRICTED, app_control_data.state);
+}
+
+void test_m4_sample_length_wins_over_sample_tension(void)
+{
+    control_init();
+    enableMotion();
+    d_testRunning = true;
+    d_forceExceeded = true;
+    d_displacementExceeded = true;
+    app_control_run();
+    TEST_ASSERT_EQUAL_INT(APP_CONTROL_RESTRICTION_SAMPLE_LENGTH, app_control_getRestriction());
 }
 
 /* Restriction priority chain: MACHINE_TENSION < UPPER < LOWER < DOOR indices. */
@@ -743,7 +790,10 @@ int main(void)
     RUN_TEST(test_m4_enable_refused_for_each_fault);
     RUN_TEST(test_m4_first_fault_wins_adjacent_pairs);
     RUN_TEST(test_m4_each_active_restriction_alone);
-    RUN_TEST(test_m4_sample_restrictions_inactive_today);
+    RUN_TEST(test_m4_sample_restrictions_inactive_when_not_running);
+    RUN_TEST(test_m4_sample_tension_restricts_while_test_running);
+    RUN_TEST(test_m4_sample_length_restricts_while_test_running);
+    RUN_TEST(test_m4_sample_length_wins_over_sample_tension);
     RUN_TEST(test_m4_restriction_priority_chain);
 
     return UNITY_END();

--- a/Firmware/MaDCore/test/test_dev_servo/test_dev_servo.c
+++ b/Firmware/MaDCore/test/test_dev_servo/test_dev_servo.c
@@ -1,0 +1,349 @@
+/*
+ * Unit tests for src/DEV/dev_servo.c — closed-loop motion backend.
+ *
+ * Coverage (certification contracts parallel to test_dev_stepper):
+ *   - init: disabled, atTarget, encoder position is source of truth
+ *   - enable / disable idle park
+ *   - moveTo stages target; invalid feedrate clamps to maxVelocity
+ *   - atTarget when encoder is inside deadband and profile is settled
+ *   - velocity mode commands a non-zero pulse train
+ *   - stop requests velocity hold at 0
+ *   - setPosition redefines encoder reference + target
+ *   - following error reflects setpoint vs encoder
+ *   - stall guard latches after stallTicks of commanding without motion
+ *
+ * HAL_encoder / HAL_pulseOut / HAL_GPIO / HAL_time are local doubles.
+ * Library is real (linked by native_test). Module is #included after doubles.
+ */
+
+#include <unity.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <math.h>
+
+#include "HAL_lock.h"
+#include "HAL_GPIO.h"
+#include "HAL_pulseOut.h"
+#include "HAL_encoder.h"
+#include "HAL_time.h"
+
+/* ====================================================================== *
+ * Test doubles                                                            *
+ * ====================================================================== */
+
+static int32_t d_encoderValue;
+static int d_encoderSetCount;
+static int32_t d_encoderLastSet;
+
+void HAL_encoder_start(HAL_encoder_channel_E ch) { (void)ch; }
+int32_t HAL_encoder_value(HAL_encoder_channel_E ch)
+{
+    (void)ch;
+    return d_encoderValue;
+}
+void HAL_encoder_set(HAL_encoder_channel_E ch, int32_t v)
+{
+    (void)ch;
+    d_encoderSetCount++;
+    d_encoderLastSet = v;
+    d_encoderValue = v;
+}
+
+static uint32_t d_startVelocityCount;
+static uint32_t d_startVelocityFreq;
+static uint32_t d_setFrequencyCount;
+static uint32_t d_lastSetFrequency;
+static uint32_t d_stopCount;
+static uint32_t d_runCount;
+static uint32_t d_run_delta;
+
+void HAL_pulseOut_start(HAL_pulseOut_channel_E channel, uint32_t pulses, uint32_t frequency)
+{
+    (void)channel;
+    (void)pulses;
+    (void)frequency;
+}
+
+bool HAL_pulseOut_run(HAL_pulseOut_channel_E channel, uint32_t *pulses)
+{
+    (void)channel;
+    d_runCount++;
+    if (pulses != NULL)
+    {
+        *pulses = d_run_delta;
+    }
+    return false;
+}
+
+void HAL_pulseOut_stop(HAL_pulseOut_channel_E channel)
+{
+    (void)channel;
+    d_stopCount++;
+}
+
+void HAL_pulseOut_startVelocity(HAL_pulseOut_channel_E channel, uint32_t frequency)
+{
+    (void)channel;
+    d_startVelocityCount++;
+    d_startVelocityFreq = frequency;
+}
+
+void HAL_pulseOut_setFrequency(HAL_pulseOut_channel_E channel, uint32_t frequency)
+{
+    (void)channel;
+    d_setFrequencyCount++;
+    d_lastSetFrequency = frequency;
+}
+
+static uint32_t d_gpioCount;
+static HAL_GPIO_channel_E d_gpioChannel;
+static bool d_gpioActive;
+
+void HAL_GPIO_setActive(HAL_GPIO_channel_E channel, bool active)
+{
+    d_gpioCount++;
+    d_gpioChannel = channel;
+    d_gpioActive = active;
+}
+
+/* global_timeus is provided by mock_propeller2.c (HAL_time_getUs). */
+extern uint32_t global_timeus;
+extern void HAL_lock_mock_reset(void);
+extern int _stdio_debug_lock;
+
+/* Module under test after doubles. */
+#include "../../src/DEV/dev_servo.c"
+
+#define CH DEV_SERVO_CHANNEL_MAIN
+
+static void doubles_reset(void)
+{
+    d_encoderValue = 0;
+    d_encoderSetCount = 0;
+    d_encoderLastSet = 0;
+    d_startVelocityCount = 0U;
+    d_startVelocityFreq = 0U;
+    d_setFrequencyCount = 0U;
+    d_lastSetFrequency = 0U;
+    d_stopCount = 0U;
+    d_runCount = 0U;
+    d_run_delta = 0U;
+    d_gpioCount = 0U;
+    d_gpioChannel = HAL_GPIO_COUNT;
+    d_gpioActive = false;
+    global_timeus = 0U;
+}
+
+static void servo_init(void)
+{
+    HAL_lock_mock_reset();
+    _stdio_debug_lock = HAL_lock_create();
+    doubles_reset();
+    memset(&dev_servo_data, 0, sizeof(dev_servo_data));
+    /* maxVelocity/maxAccel > 0 so tests use deterministic profile limits. */
+    dev_servo_init(HAL_lock_create(), 100000 /* counts/s */, 500000 /* counts/s^2 */);
+}
+
+void setUp(void)
+{
+    HAL_lock_mock_reset();
+    _stdio_debug_lock = HAL_lock_create();
+    global_timeus = 0U;
+}
+
+void tearDown(void) {}
+
+/* Advance the control loop by one nominal tick (1 ms default). */
+static void tick(void)
+{
+    global_timeus += 1000U;
+    dev_servo_run();
+}
+
+/**********************************************************************
+ * Tests
+ **********************************************************************/
+
+void test_dev_servo_initialStateDisabledAtTarget(void)
+{
+    servo_init();
+    TEST_ASSERT_TRUE(dev_servo_atTarget(CH));
+    TEST_ASSERT_FALSE(dev_servo_isStalled(CH));
+    TEST_ASSERT_EQUAL_INT32(0, dev_servo_getPosition(CH));
+    TEST_ASSERT_EQUAL_INT32(0, dev_servo_getVelocity(CH));
+    TEST_ASSERT_EQUAL_INT32(0, dev_servo_getFollowingError(CH));
+}
+
+void test_dev_servo_disabledParksAndReportsEncoder(void)
+{
+    servo_init();
+    d_encoderValue = 1234;
+    tick();
+    TEST_ASSERT_EQUAL_INT32(1234, dev_servo_getPosition(CH));
+    TEST_ASSERT_TRUE(dev_servo_atTarget(CH));
+    TEST_ASSERT_EQUAL_INT32(0, dev_servo_getVelocity(CH));
+    /* No velocity train while disabled. */
+    TEST_ASSERT_EQUAL_UINT32(0U, d_startVelocityCount);
+}
+
+void test_dev_servo_moveToStagesTarget(void)
+{
+    servo_init();
+    dev_servo_moveTo(CH, 5000, 10000);
+    TEST_ASSERT_EQUAL_INT32(5000, dev_servo_getTarget(CH));
+    /* Not applied until enable + run. */
+    TEST_ASSERT_EQUAL_INT32(0, dev_servo_getPosition(CH));
+}
+
+void test_dev_servo_moveToInvalidFeedrateUsesMax(void)
+{
+    servo_init();
+    /* 0 and oversize clamp to maxVelocity (100000 from init). */
+    dev_servo_moveTo(CH, 100, 0);
+    TEST_ASSERT_EQUAL_INT32(100000, dev_servo_data.channel[CH].req.feedrate);
+    dev_servo_moveTo(CH, 100, 999999);
+    TEST_ASSERT_EQUAL_INT32(100000, dev_servo_data.channel[CH].req.feedrate);
+}
+
+void test_dev_servo_atTargetWhenEncoderSettledOnTarget(void)
+{
+    servo_init();
+    d_encoderValue = 0;
+    dev_servo_enable(CH, true);
+    dev_servo_moveTo(CH, 0, 10000);
+    tick();
+    TEST_ASSERT_TRUE(dev_servo_atTarget(CH));
+    TEST_ASSERT_EQUAL_INT32(0, dev_servo_getVelocity(CH));
+}
+
+void test_dev_servo_positionMoveCommandsVelocity(void)
+{
+    servo_init();
+    d_encoderValue = 0;
+    dev_servo_enable(CH, true);
+    dev_servo_moveTo(CH, 10000, 20000);
+    tick();
+    /* Should be ramping toward target — non-zero command and velocity train. */
+    TEST_ASSERT_FALSE(dev_servo_atTarget(CH));
+    TEST_ASSERT_TRUE(dev_servo_getVelocity(CH) != 0 || d_startVelocityCount > 0U);
+    TEST_ASSERT_TRUE(d_startVelocityCount + d_setFrequencyCount > 0U);
+}
+
+void test_dev_servo_velocityModeCommandsPulseTrain(void)
+{
+    servo_init();
+    d_encoderValue = 0;
+    dev_servo_enable(CH, true);
+    dev_servo_setVelocity(CH, 5000);
+    /* Several ticks so accel ramp reaches a non-trivial command. */
+    for (int i = 0; i < 20; i++)
+    {
+        tick();
+    }
+    TEST_ASSERT_TRUE(d_startVelocityCount > 0U);
+    TEST_ASSERT_TRUE(dev_servo_getVelocity(CH) != 0);
+}
+
+void test_dev_servo_stopRequestsZeroVelocityTarget(void)
+{
+    servo_init();
+    d_encoderValue = 0;
+    dev_servo_enable(CH, true);
+    dev_servo_setVelocity(CH, 8000);
+    for (int i = 0; i < 10; i++)
+    {
+        tick();
+    }
+    TEST_ASSERT_TRUE(dev_servo_getVelocity(CH) != 0);
+
+    dev_servo_stop(CH);
+    /* stop() is a velocity-mode hold at 0 — stages targetVel, does not instantly
+     * zero the closed-loop command (Kp still fights frozen-encoder error). */
+    TEST_ASSERT_EQUAL_INT(DEV_SERVO_MODE_VELOCITY, dev_servo_data.channel[CH].req.mode);
+    TEST_ASSERT_EQUAL_INT32(0, dev_servo_data.channel[CH].req.targetVel);
+
+    /* When the encoder is free to track the setpoint, command winds down to 0. */
+    for (int i = 0; i < 100; i++)
+    {
+        /* Ideal plant: encoder snaps toward setpoint each tick. */
+        d_encoderValue = (int32_t)dev_servo_data.channel[CH].setpointPos;
+        tick();
+    }
+    TEST_ASSERT_EQUAL_INT32(0, dev_servo_getVelocity(CH));
+}
+
+void test_dev_servo_setPositionUpdatesEncoderAndTarget(void)
+{
+    servo_init();
+    dev_servo_setPosition(CH, 4096);
+    TEST_ASSERT_EQUAL_INT32(4096, d_encoderLastSet);
+    TEST_ASSERT_EQUAL_INT32(4096, d_encoderValue);
+    TEST_ASSERT_EQUAL_INT32(4096, dev_servo_getTarget(CH));
+}
+
+void test_dev_servo_followingErrorReflectsOffset(void)
+{
+    servo_init();
+    d_encoderValue = 0;
+    dev_servo_enable(CH, true);
+    dev_servo_moveTo(CH, 50000, 50000);
+    /* Advance setpoint without moving encoder → following error grows. */
+    for (int i = 0; i < 30; i++)
+    {
+        tick();
+    }
+    TEST_ASSERT_TRUE(dev_servo_getFollowingError(CH) > 0);
+}
+
+void test_dev_servo_stallWhenCommandedWithoutMotion(void)
+{
+    servo_init();
+    d_encoderValue = 0; /* frozen encoder */
+    dev_servo_enable(CH, true);
+    /* High velocity so |cmd| > stallVelocity (default 4096). */
+    dev_servo_setVelocity(CH, 20000);
+    /* stallTicks default = 200. */
+    for (int i = 0; i < 250; i++)
+    {
+        tick();
+    }
+    TEST_ASSERT_TRUE(dev_servo_isStalled(CH));
+}
+
+void test_dev_servo_disableClearsStallAndParks(void)
+{
+    servo_init();
+    d_encoderValue = 0;
+    dev_servo_enable(CH, true);
+    dev_servo_setVelocity(CH, 20000);
+    for (int i = 0; i < 250; i++)
+    {
+        tick();
+    }
+    TEST_ASSERT_TRUE(dev_servo_isStalled(CH));
+
+    dev_servo_enable(CH, false);
+    tick();
+    TEST_ASSERT_FALSE(dev_servo_isStalled(CH));
+    TEST_ASSERT_TRUE(dev_servo_atTarget(CH));
+    TEST_ASSERT_EQUAL_INT32(0, dev_servo_getVelocity(CH));
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_dev_servo_initialStateDisabledAtTarget);
+    RUN_TEST(test_dev_servo_disabledParksAndReportsEncoder);
+    RUN_TEST(test_dev_servo_moveToStagesTarget);
+    RUN_TEST(test_dev_servo_moveToInvalidFeedrateUsesMax);
+    RUN_TEST(test_dev_servo_atTargetWhenEncoderSettledOnTarget);
+    RUN_TEST(test_dev_servo_positionMoveCommandsVelocity);
+    RUN_TEST(test_dev_servo_velocityModeCommandsPulseTrain);
+    RUN_TEST(test_dev_servo_stopRequestsZeroVelocityTarget);
+    RUN_TEST(test_dev_servo_setPositionUpdatesEncoderAndTarget);
+    RUN_TEST(test_dev_servo_followingErrorReflectsOffset);
+    RUN_TEST(test_dev_servo_stallWhenCommandedWithoutMotion);
+    RUN_TEST(test_dev_servo_disableClearsStallAndParks);
+    return UNITY_END();
+}

--- a/Software/Control/e2e/capture-screenshots.mjs
+++ b/Software/Control/e2e/capture-screenshots.mjs
@@ -19,14 +19,10 @@
  * from the connected emulator.
  */
 
-import { createRequire } from 'node:module';
 import { mkdir } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve } from 'node:path';
-import { installFakeSerial, installOpfsDataDir, APP_URL, BRIDGE_URL, OPFS_DIR } from './fixtures.mjs';
-
-const require = createRequire('/Users/rileymccarthy/Documents/MaD/SIL/');
-const { chromium } = require('playwright');
+import { installFakeSerial, installOpfsDataDir, APP_URL, BRIDGE_URL, OPFS_DIR, chromium } from './fixtures.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const OUT = process.env.SHOT_DIR || resolve(HERE, '../../../docs/assets/screenshots');

--- a/Software/Control/e2e/fixtures.mjs
+++ b/Software/Control/e2e/fixtures.mjs
@@ -20,9 +20,13 @@
  */
 
 import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 
-const require = createRequire('/Users/rileymccarthy/Documents/MaD/SIL/');
-const { chromium } = require('playwright');
+// Resolve Playwright from the SIL workspace (shared install) — portable for CI.
+const silPackageJson = join(dirname(fileURLToPath(import.meta.url)), '../../../SIL/package.json');
+const require = createRequire(silPackageJson);
+export const { chromium } = require('playwright');
 
 export const APP_URL = process.env.APP_URL || 'http://localhost:5174/';
 export const BRIDGE_URL = process.env.BRIDGE_URL || 'ws://localhost:9999';

--- a/Software/Control/e2e/matrix-catalog.json
+++ b/Software/Control/e2e/matrix-catalog.json
@@ -33,7 +33,13 @@
     "TM-manual-gate",
     "P1-precision",
     "BB-back-to-back",
+    "M8-jog-1mm-20",
     "M8-jog-4mm-20",
-    "M11-idle-drop"
+    "M8-jog-roundtrip-5",
+    "M9-mid-slack",
+    "WAVE-sine",
+    "WAVE-tri",
+    "M11-idle-drop",
+    "B5-reconnect"
   ]
 }

--- a/Software/Control/e2e/run-all.mjs
+++ b/Software/Control/e2e/run-all.mjs
@@ -19,14 +19,10 @@
  * unit/presence-covered.
  */
 
-import { newSilPage, connectToSil, chooseDataFolder, APP_URL } from './fixtures.mjs';
-import { createRequire } from 'node:module';
+import { newSilPage, connectToSil, chooseDataFolder, APP_URL, chromium } from './fixtures.mjs';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-
-const require = createRequire('/Users/rileymccarthy/Documents/MaD/SIL/');
-const { chromium } = require('playwright');
 
 /** Sprint C parameterized matrices (M8–M11). */
 const MATRIX = JSON.parse(

--- a/Software/Control/e2e/sil-playground.mjs
+++ b/Software/Control/e2e/sil-playground.mjs
@@ -14,11 +14,7 @@
  * system Google Chrome via channel.
  */
 
-import { createRequire } from 'node:module';
-import { installFakeSerial, APP_URL, BRIDGE_URL } from './fixtures.mjs';
-
-const require = createRequire('/Users/rileymccarthy/Documents/MaD/SIL/');
-const { chromium } = require('playwright');
+import { installFakeSerial, APP_URL, BRIDGE_URL, chromium } from './fixtures.mjs';
 
 async function main() {
   const browser = await chromium.launch({ channel: 'chrome', headless: false });

--- a/Software/Control/e2e/sil-smoke.mjs
+++ b/Software/Control/e2e/sil-smoke.mjs
@@ -15,10 +15,7 @@
  * Playwright/Chromium are reused from the SIL workspace.
  */
 
-import { createRequire } from 'node:module';
-
-const require = createRequire('/Users/rileymccarthy/Documents/MaD/SIL/');
-const { chromium } = require('playwright');
+import { chromium } from './fixtures.mjs';
 
 const APP_URL = process.env.APP_URL || 'http://localhost:5174';
 const BRIDGE_URL = process.env.BRIDGE_URL || 'ws://localhost:9999';

--- a/Software/Control/e2e/smoke-ids.txt
+++ b/Software/Control/e2e/smoke-ids.txt
@@ -10,5 +10,11 @@ TM-busy-restart
 TM-manual-gate
 P1-precision
 BB-back-to-back
+M8-jog-1mm-20
 M8-jog-4mm-20
+M8-jog-roundtrip-5
+M9-mid-slack
+WAVE-sine
+WAVE-tri
 M11-idle-drop
+B5-reconnect

--- a/Software/Control/package-lock.json
+++ b/Software/Control/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "mad-wasm-control",
+  "name": "mad-control",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mad-wasm-control",
+      "name": "mad-control",
       "version": "0.1.0",
       "dependencies": {
         "comlink": "^4.4.2",

--- a/Software/Control/package.json
+++ b/Software/Control/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mad-wasm-control",
+  "name": "mad-control",
   "version": "0.1.0",
   "private": true,
   "description": "Frontend-only MaD tensile-tester control app (Web Serial + WebAssembly). Chromium-only.",

--- a/Software/Control/src/store/useStore.ts
+++ b/Software/Control/src/store/useStore.ts
@@ -19,6 +19,7 @@ import {
   NotificationType,
 } from '@/domain';
 import { pushSample, resetLiveBuffer, seedSamples } from './liveBuffer';
+import { reduceDeviceEvent } from './deviceEventReduce';
 import { record } from '@/diagnostics/recorder';
 import { MSG_SAMPLE_PERIOD_MS } from '@/protocol/generated/protoemb';
 
@@ -280,94 +281,94 @@ export const useStore = create<AppState>((set, getState) => ({
     initialized = true;
     unsubscribe = deviceClient.subscribe((events: DeviceEvent[]) => {
       for (const e of events) {
-        switch (e.kind) {
-          case 'sample':
-            pushSample(e.data);
-            pendingSample = e.data;
-            lastSampleAt = Date.now();
-            break;
-          case 'state':
-            set({ machineState: e.data });
-            break;
-          case 'configuration':
-            set({ config: e.data });
-            break;
-          case 'sampleProfile':
-            set({ sampleProfile: e.data });
-            break;
-          case 'firmwareVersion':
-            set({ firmwareVersion: e.data.version });
-            break;
-          case 'connected':
-            record('info', 'connected');
-            break;
-          case 'error': {
-            record('error', 'device-error', e.message);
-            const now = Date.now();
-            if (now - lastErrorToastAt > 5000) {
-              lastErrorToastAt = now;
-              getState().notify(NotificationType.WARN, `Device error: ${e.message}`);
-            }
-            break;
+        // Pure event→patch reduction (B4); side effects (timers, toasts, record) stay here.
+        const patch = reduceDeviceEvent(e, userDisconnect);
+
+        if (patch.sample) {
+          pushSample(patch.sample);
+          pendingSample = patch.sample;
+          lastSampleAt = Date.now();
+        }
+        if (e.kind === 'state' && patch.machineState !== undefined) {
+          set({ machineState: patch.machineState });
+        }
+        if (patch.config !== undefined) set({ config: patch.config });
+        if (patch.sampleProfile !== undefined) set({ sampleProfile: patch.sampleProfile });
+        if (patch.firmwareVersion !== undefined) set({ firmwareVersion: patch.firmwareVersion });
+
+        if (patch.counters) {
+          for (const c of patch.counters) {
+            if (c === 'connected') record('info', 'connected');
+            else if (c === 'device-error' && e.kind === 'error') record('error', 'device-error', e.message);
+            else if (c === 'timeout') record('warn', 'timeout');
+            else if (c === 'nack' && e.kind === 'ack') record('warn', 'nack', `command ${e.command}`);
           }
-          case 'timeout':
-            record('warn', 'timeout');
-            break;
-          case 'ack':
-            if (!e.success) record('warn', 'nack', `command ${e.command}`);
-            break;
-          case 'notification':
+        }
+
+        if (patch.errorToast) {
+          const now = Date.now();
+          if (now - lastErrorToastAt > 5000) {
+            lastErrorToastAt = now;
+            getState().notify(NotificationType.WARN, patch.errorToast);
+          }
+        }
+
+        if (patch.notification) {
+          set((s) => ({
+            notifications: [
+              ...s.notifications.slice(-49),
+              {
+                Type: patch.notification!.Type as NotificationType,
+                Message: patch.notification!.Message,
+                id: (notificationSeq += 1),
+                t: Date.now(),
+              },
+            ],
+          }));
+        }
+
+        if (patch.disconnect) {
+          const lost = patch.disconnect.unexpected;
+          userDisconnect = false;
+          stopTimers();
+          record(lost ? 'warn' : 'info', 'disconnected', patch.disconnect.reason ?? '');
+          // Flush the freshest sample so the frozen readouts show the true last
+          // reading at the moment of loss (the 250ms mirror could be stale).
+          const flushed = pendingSample;
+          pendingSample = null;
+          set({
+            connection: 'disconnected',
+            machineState: patch.machineState ?? null,
+            responding: false,
+            ...(flushed ? { latestSample: flushed } : {}),
+            ...(lost
+              ? {
+                  error: patch.disconnect.reason
+                    ? `Device disconnected (${patch.disconnect.reason})`
+                    : 'Device disconnected',
+                  canReconnect: lastPort !== null,
+                }
+              : {}),
+          });
+          if (lost) {
             set((s) => ({
               notifications: [
                 ...s.notifications.slice(-49),
-                { ...e.data, id: (notificationSeq += 1), t: Date.now() },
+                {
+                  Type: NotificationType.ERROR,
+                  Message: 'Device disconnected — check the cable, then Reconnect.',
+                  id: (notificationSeq += 1),
+                  t: Date.now(),
+                },
               ],
             }));
-            break;
-          case 'disconnected': {
-            const lost = !userDisconnect;
-            userDisconnect = false;
-            stopTimers();
-            record(lost ? 'warn' : 'info', 'disconnected', e.reason ?? '');
-            // Flush the freshest sample so the frozen readouts show the true last
-            // reading at the moment of loss (the 250ms mirror could be stale).
-            const flushed = pendingSample;
-            pendingSample = null;
-            set({
-              connection: 'disconnected',
-              machineState: null,
-              responding: false,
-              ...(flushed ? { latestSample: flushed } : {}),
-              ...(lost
-                ? {
-                    error: e.reason ? `Device disconnected (${e.reason})` : 'Device disconnected',
-                    canReconnect: lastPort !== null,
-                  }
-                : {}),
-            });
-            if (lost) {
-              set((s) => ({
-                notifications: [
-                  ...s.notifications.slice(-49),
-                  {
-                    Type: NotificationType.ERROR,
-                    Message: 'Device disconnected — check the cable, then Reconnect.',
-                    id: (notificationSeq += 1),
-                    t: Date.now(),
-                  },
-                ],
-              }));
-            }
-            break;
           }
-          case 'portAvailable': {
-            // The device came back (replug) — try to resume automatically.
-            const s = getState();
-            if (s.connection === 'disconnected' && s.canReconnect) void s.reconnect();
-            break;
-          }
-          default:
-            break;
+        }
+
+        if (e.kind === 'portAvailable') {
+          // The device came back (replug) — try to resume automatically.
+          const s = getState();
+          if (s.connection === 'disconnected' && s.canReconnect) void s.reconnect();
         }
       }
     });

--- a/docs/dev/backend-certification.md
+++ b/docs/dev/backend-certification.md
@@ -6,7 +6,7 @@ CI unit and SIL coverage default to the **stepper** path.
 | Backend | Automated coverage | Status |
 |---------|-------------------|--------|
 | **Stepper** (`dev_stepper`) | Unity `test_dev_stepper`, `test_app_motion` (stepper-pinned), SIL/WASM e2e | **Certified for CI** |
-| **Servo** (`dev_servo`) | No dedicated Unity suite yet | **Not CI-certified** — hardware/HIL or future unit suite |
+| **Servo** (`dev_servo`) | Unity `test_dev_servo` (enable/move/velocity/stop/stall contracts) | **Unit-certified** — SIL still links stepper; HIL for plant fidelity |
 
 ## PR checklist
 
@@ -17,9 +17,9 @@ When changing motion/HAL:
    section and describe manual/HIL verification.
 3. Do not claim “motion covered” in CI unless the stepper suite still passes.
 
-## Adding servo certification later
+## Servo unit suite
 
-- Add `test_dev_servo` with the same move/queue/home contracts as stepper where
-  the public API is shared.
-- Optionally add a SIL feature flag for servo models.
-- Promote this table when those gates are green.
+- `test_dev_servo` covers enable, moveTo/atTarget, velocity mode, stop, setPosition,
+  following-error readout, and stall detection against HAL doubles.
+- SIL/WASM e2e still exercise the **stepper** backend (default plant). Plant-model
+  servo fidelity remains HIL / future SIL flag work.

--- a/docs/dev/bulletproof-test-plan.md
+++ b/docs/dev/bulletproof-test-plan.md
@@ -54,8 +54,7 @@ Out-of-range packed fields never encode (bit-wrap).
 ### B1 — M4 Fault × restriction tables
 
 - `test_app_control.c`: each fault alone + enable refused; adjacent first-fault-wins;
-  each active restriction alone; priority chain; sample restrictions locked inactive
-  (firmware checks currently commented).
+  each active restriction alone; priority chain; sample restrictions via app_monitor flags.
 
 ### B2 — M5 Lifecycle matrix
 


### PR DESCRIPTION
## Summary

Rebased onto `main` after #29 landed the `Software/Control` rename. **Rename hunks dropped** (already on main). Remaining:

1. **E2E CI** — portable Playwright resolve via `import.meta.url` (no hard-coded macOS path); nightly installs wasm-pack + wasm32 and waits for PTY + bridge.
2. **Servo certification** — Unity `test_dev_servo`; `backend-certification.md`; `native_test_noasan` helper.
3. **`reduceDeviceEvent` → `useStore`** — B4 reducer drives the subscribe path.
4. **Sample restrictions re-enabled** while `testRunning`; M4 tests flipped active.
5. **Smoke expansion** — M8×3, M9-mid-slack, WAVE-sine/tri, M11-idle-drop, B5-reconnect.

Nightly workflow uses `setup-python@v7` (already on main) + rust `wasm32-unknown-unknown`.

## Test plan

- [ ] firmware-unit-tests (app_control + test_dev_servo)
- [ ] wasm-control-ci
- [ ] CI Gate