### PR TITLE
docs(operators): cover browser firmware flashing, first update and staying current

### DIFF
--- a/Software/Control/docs/FLASHING.md
+++ b/Software/Control/docs/FLASHING.md
@@ -48,10 +48,13 @@ From `Hardware/EdgeBoard/KiCad/MaD_Edge.kicad_sch`, connector **J1**
 ("Debug/Programming", `Conn_01x04`) carries, in order:
 
 ```
-GND / RESn / P63 / P62
+pin 1: P62    pin 2: P63    pin 3: RESn    pin 4: GND
 ```
 
-That is the standard Parallax Prop Plug pinout, and P62/P63 is also where a
+(Confirmed against the pad-to-net assignments in `MaD_Edge.kicad_pcb`; an earlier
+revision of this document listed the four nets in reverse pin order.)
+
+P62/P63 is also where a
 production firmware build puts the protocol UART (`HAL_serial.c`, with
 `ENABLE_DEBUG_SERIAL` off). So on production hardware **one connection serves
 both control and programming** — the app defaults to reusing the port it is

--- a/Software/Control/src/ui/screens/About.tsx
+++ b/Software/Control/src/ui/screens/About.tsx
@@ -38,7 +38,11 @@ export default function About() {
         </p>
         <p className="muted">
           Firmware releases:{' '}
-          <a href="https://github.com/" target="_blank" rel="noreferrer">
+          <a
+            href="https://github.com/RileyMcCarthy/MaD/releases"
+            target="_blank"
+            rel="noreferrer"
+          >
             GitHub
           </a>
         </p>

--- a/Software/Control/src/ui/screens/Firmware.tsx
+++ b/Software/Control/src/ui/screens/Firmware.tsx
@@ -100,8 +100,8 @@ export default function Firmware() {
         <p className="muted">
           Programs the Propeller 2 directly from the browser over the same USB-serial adapter
           used for control — the loader resets the chip with DTR and talks to its boot ROM.
-          This needs the Debug/Programming header J1 (GND / RESn / P63 / P62) and an adapter
-          that drives RESn from DTR, such as a Parallax Prop Plug. The isolated Raspberry Pi
+          This uses the Debug/Programming header J1 (pin 1 P62, 2 P63, 3 RESn, 4 GND) and
+          needs an adapter that drives RESn from DTR, such as a Parallax Prop Plug. The isolated Raspberry Pi
           link on P53/P55 has no reset line and cannot program the board.
         </p>
 

--- a/docs/dev/protocol-messages.md
+++ b/docs/dev/protocol-messages.md
@@ -51,7 +51,7 @@ sampleCount(u32)`) and the device streams `StoredSample` records.
 | `Move` | packed | 8 B | A G-code move (position/velocity/dwell) |
 | `WaveformMove` | packed | 9 B | A `G123` waveform canned cycle (shape, amplitude, frequency, cycles) |
 | `StoredSample` | packed | 11 B | A logged sample data point |
-| `MachineConfiguration` | aligned | 68 B | Calibration & limits (NVRAM) |
+| `MachineConfiguration` | aligned | 64 B | Calibration & limits (NVRAM) |
 | `SampleProfile` | aligned | 20 B | Per-test material limits |
 | `TestRun` | aligned | 14 B | gcodeId + testDataId references |
 | `FirmwareVersion` | aligned | 16 B | Version string |

--- a/docs/getting-started/operators.md
+++ b/docs/getting-started/operators.md
@@ -35,6 +35,12 @@ When connected, the status bar turns green and shows **Connected** with a
 
 [:octicons-arrow-right-24: More on connecting](../user-guide/connecting.md)
 
+!!! tip "Check the firmware version once you're connected"
+    Open **Firmware** in the sidebar — it shows what the machine is running. If
+    it's older than the current release, you can update it from the app; see
+    [Keeping the firmware up to date](#keeping-the-firmware-up-to-date) at the end
+    of this page. You don't have to do this before your first test.
+
 ## 3. Watch live data
 
 Open **Live**. You'll see real-time readouts (machine and sample force/position),
@@ -90,6 +96,49 @@ off the machine, then **View** to see the analysis — force vs time, position
 (actual / setpoint / expected), and a stress–strain curve:
 
 [:octicons-arrow-right-24: Test history & analysis](../user-guide/test-history-and-analysis.md)
+
+## Keeping the firmware up to date
+
+The machine runs its own firmware, updated separately from the app. You can
+program it from the browser over the same USB connection you already use for
+control — there's no separate tool to install.
+
+!!! warning "New capability — try RAM mode first"
+    Browser flashing is newly added and hasn't yet been confirmed against a
+    physical board. Do your first update with the machine on the bench rather than
+    before a run, and start with **Load into RAM** — it's the reversible mode, and
+    a power cycle undoes it.
+
+### Before you start
+
+Flashing needs the **Debug/Programming header (J1)** and an adapter that drives
+RESn from DTR, such as a Parallax Prop Plug — that's how the app resets the chip
+to reach its boot ROM. On production hardware this is the same connection you
+use for control, so if the machine is talking to the app, it can be programmed.
+
+The isolated Raspberry Pi link has no reset line and **cannot** program the board.
+
+### First-time update
+
+1. Open **Firmware** and note the version under **Current firmware**.
+2. Download the latest `MaD-Firmware-<version>-release.bin` from the project's
+   GitHub releases page. (The `-debug` build is for bench work — take the
+   **release** one.)
+3. Select **Load into RAM**, choose the file, and click **Load into RAM**. This
+   runs the new firmware without writing anything permanent.
+4. Reconnect and check the machine behaves as expected.
+5. Once you're satisfied, repeat with **Write to flash** to make it permanent.
+
+### Staying current
+
+Check the version on the **Firmware** screen against the latest release now and
+then — there's no automatic notification for firmware. A good habit is to check
+whenever you update the app, since the two travel together.
+
+Because RAM mode is non-destructive, it's a cheap way to try a new build before
+committing it to flash.
+
+[:octicons-arrow-right-24: Full firmware & diagnostics guide](../user-guide/firmware-and-diagnostics.md)
 
 ---
 

--- a/docs/user-guide/firmware-and-diagnostics.md
+++ b/docs/user-guide/firmware-and-diagnostics.md
@@ -1,7 +1,8 @@
 # Firmware & diagnostics
 
 The **Firmware** screen shows the firmware version reported by the connected
-machine and lets you export a diagnostics bundle for troubleshooting.
+machine, lets you update that firmware, and exports a diagnostics bundle for
+troubleshooting.
 
 ![The Firmware / About screen](../assets/screenshots/09-firmware.png)
 
@@ -11,6 +12,77 @@ When the machine is connected and responding, its **firmware version** is shown
 here (and in the status bar). If it shows nothing, the firmware isn't responding —
 see [Troubleshooting](troubleshooting.md).
 
+## Updating the firmware
+
+!!! warning "New capability — validate before relying on it"
+    Browser flashing is newly added and has been proven against unit tests and a
+    reference implementation, but **not yet against a physical board**. Until it
+    has been confirmed on your hardware, treat a flash as something to attempt
+    with the machine on the bench and time to recover — not mid-session before a
+    run. **Load into RAM** first: it is the reversible mode, and a power cycle
+    undoes it.
+
+The app programs the Propeller 2 over the same USB connection it uses for
+control. There is nothing to install.
+
+### What you need
+
+- The **Debug/Programming header (J1)** connected — `GND / RESn / P63 / P62`,
+  the standard Parallax 4-pin pinout.
+- A USB-serial adapter that **drives RESn from DTR**, such as a Parallax Prop
+  Plug. The app resets the chip that way to reach its boot ROM.
+
+On production hardware the control link and the programming link are the same
+connection, so if you can already talk to the machine, you can already program it.
+
+!!! danger "The isolated Raspberry Pi link cannot program the board"
+    The isolated link on P53/P55 has **no reset line**, so flashing over it will
+    not work no matter what else is correct. Use the J1 header.
+
+### Two modes
+
+| Mode | What it does | When to use it |
+|---|---|---|
+| **Load into RAM** | Runs the firmware immediately. Lost at the next reset or power cycle. | Trying a build, or a first attempt — nothing is written permanently |
+| **Write to flash** | Copies the firmware into the machine's flash. Survives power cycling. | The real update, once you're confident |
+
+### Doing the update
+
+1. **Connect to the machine** as usual, and note the version shown under
+   **Current firmware** so you can confirm the change afterwards.
+2. **Get the firmware file.** Releases are published on the project's GitHub
+   releases page as `MaD-Firmware-<version>-release.bin`. There is also a
+   `-debug` build, which moves the protocol link to different pins and is meant
+   for bench work — for normal use, take the **release** file.
+3. On the **Firmware** screen, choose **Load into RAM** or **Write to flash**.
+4. Click **Choose file** and pick the `.bin`. The app shows its size and roughly
+   how long the transfer will take — a few seconds for a typical image.
+5. Click **Write to flash** / **Load into RAM**. The status line walks through
+   *Resetting the board and waking its boot ROM…*, then *Uploading… n%*, then
+   *Finishing…*.
+6. When it completes, confirm the version under **Current firmware** is the one
+   you just installed.
+
+!!! tip "Bench setups with two adapters"
+    **Choose a different port for programming** is only for setups where control
+    and programming run over separate adapters — which happens with a debug
+    firmware build, since that moves the protocol link to other pins. On
+    production hardware, leave it unchecked. The browser can't tell two identical
+    adapters apart, so if you do check it, you pick the port yourself.
+
+### If it doesn't work
+
+- **Nothing happens, or it fails while resetting** — the adapter probably isn't
+  driving RESn from DTR, or you're on the isolated Raspberry Pi link. Check you're
+  on J1 with a Prop Plug or equivalent.
+- **It fails partway through the upload** — retry. If it keeps failing, power-cycle
+  the machine and try **Load into RAM** first.
+- **The version doesn't change after a flash** — the machine may have rebooted into
+  the previous image. Power-cycle it, reconnect, and check again.
+
+A failed **RAM** load changes nothing permanent: power-cycle and the machine comes
+back on its existing firmware.
+
 ## Diagnostics export
 
 Click **Download diagnostics** to save a file recording what the app has been
@@ -19,13 +91,7 @@ performance counters. It contains **no test data**, so it's safe to attach when
 reporting a problem.
 
 !!! info "Updating the app"
-    When a new version of the app is published, the status bar shows an **Update
-    ready** button. The update is applied only when you click it **and** are idle
-    and disconnected — the app will never reload itself mid-test.
-
-## Flashing firmware
-
-!!! warning "Not available in the browser"
-    Updating the **firmware on the machine** needs a desktop tool that a browser
-    can't run, so it isn't something you can do from this app. It's covered in the
-    [developer guide](../dev/building-firmware.md).
+    The app and the firmware update separately. When a new version of the **app**
+    is published, the status bar shows an **Update ready** button. It is applied
+    only when you click it **and** are idle and disconnected — the app will never
+    reload itself mid-test.

--- a/docs/user-guide/firmware-and-diagnostics.md
+++ b/docs/user-guide/firmware-and-diagnostics.md
@@ -27,8 +27,8 @@ control. There is nothing to install.
 
 ### What you need
 
-- The **Debug/Programming header (J1)** connected — `GND / RESn / P63 / P62`,
-  the standard Parallax 4-pin pinout.
+- A cable to the board's **Debug/Programming header (J1)** — the 4-pin header
+  fitted to every EdgeBoard, wired pin 1→4 as `P62 / P63 / RESn / GND`.
 - A USB-serial adapter that **drives RESn from DTR**, such as a Parallax Prop
   Plug. The app resets the chip that way to reach its boot ROM.
 

--- a/docs/user-guide/motion-profiles.md
+++ b/docs/user-guide/motion-profiles.md
@@ -26,7 +26,9 @@ left). You can add and delete sets and moves freely.
 | **Dwell** | time (ms) | Hold position for a fixed time. |
 | **Waveform** | centre, amplitude, frequency, cycles | A smooth sine oscillation about the centre, for cyclic / fatigue loading. |
 
-Each move has an **absolute / relative** selector. For the **Waveform** move, the
+Each move has an **absolute / relative** selector, which also renames the waveform's centre field: **Centre** is a position when absolute, **Centre offset** a distance from where the machine already is when relative.
+
+For the **Waveform** move, the
 app shows the live **peak velocity** and **duration**, and warns you if it would
 exceed the machine's velocity limit. The machine generates the oscillation
 itself, so long cyclic runs continue unattended.


### PR DESCRIPTION
The **Firmware & diagnostics** page told operators that updating machine firmware
*"needs a desktop tool that a browser can't run"* and sent them to the developer
guide. #54 made that false — the app programs the P2 over the same USB connection
it already uses for control.

## Operator docs

**`user-guide/firmware-and-diagnostics.md`** — replaces the "not available"
warning with the real workflow: hardware prerequisites, **Load into RAM** vs
**Write to flash** framed by which is reversible, a step-by-step update ending on
verifying the version actually changed, the two-adapter bench case, and failure
symptoms. It calls out that the isolated Raspberry Pi link on P53/P55 has no reset
line and *cannot* program the board.

**`getting-started/operators.md`** — a version check after connecting (explicitly
not required before a first test, so the walkthrough stays a fast path), plus a
**Keeping the firmware up to date** section for the first update and staying
current. There's no automatic firmware notification, so it suggests checking
whenever the app updates.

## J1 pinout was documented backwards

`MaD_Edge.kicad_pcb` assigns J1 **pin 1 = P62, 2 = P63, 3 = RESn, 4 = GND**.
`FLASHING.md` stated `GND / RESn / P63 / P62` "in order" — exactly reversed — and
that string had been copied into the Firmware screen and the new operator docs.
A backwards pin 1 is the difference between a working connection and a dead one,
so all three copies are corrected. J1 is also no longer described as something to
be "connected": it's the 4-pin Debug header fitted to every EdgeBoard (schematic
Value `Debug`), not an add-on.

## Audit of this session's doc changes against source

| Doc | Checked against | Result |
|---|---|---|
| `protocol-messages.md` | `MaDProtocol.yaml` | 16/16 command IDs + priorities correct |
| | fresh `generate.py --target rs` | 10/10 wire sizes match |
| `gcode.md` + messages | `GCode` enum | 10/10 variants and values, both listings |
| `machine-states.md` | Faulted/RestrictedReason | full coverage, no extras |
| `machine-configuration.md` | `Config.tsx` | every field label verbatim |
| `file-formats.md` | `types.ts`, `sample.ts:19` | 9/9 move params; CSV header exact |
| `live-monitoring.md` | `Live.tsx` | all 5 readouts |
| `sil-testing.md` | `SIL/makefile` | targets match exactly |
| `ci-cd-and-releases.md` | `ci.yml` | no rows for deleted jobs |

**The audit caught a regression from an earlier commit on `main`.**
`MachineConfiguration` had been changed to **68 B** on the strength of
`Protocol/rust/src/generated/protoemb.rs` in a local checkout — a **gitignored
artifact dated 2026-07-27**. The schema yields **64 B**, as the doc originally
said. Reverted here. (`Move` 7 → 8 B was correct and stands.)

The audit also surfaced that the waveform **centre** field is labelled *"Centre"*
in absolute mode and *"Centre offset"* in relative mode; now documented.

## On how flashing is framed

`Software/Control/docs/FLASHING.md` records that the RAM and flash paths **have
not been run against a physical board** — DTR→RESn reset, the reset→autobaud
window from JavaScript, and the flash stub against this board's SPI part are all
listed as open validation. So the operator docs lead with **Load into RAM**, the
mode a power cycle undoes, and say a first update belongs on the bench rather than
before a run. Worth softening once it's confirmed on hardware.

## Also

Repoints the About screen's **Firmware releases** link, which was a placeholder
`https://github.com/`.

## Verification

- `mkdocs build --strict` clean; the in-page anchor to the new section resolves
- `npm run verify` — 273/273

🤖 Generated with [Claude Code](https://claude.com/claude-code)