### PR TITLE
feat(control): land the diagnostics work on main

### DIFF
--- a/.github/ISSUE_TEMPLATE/app-bug.yml
+++ b/.github/ISSUE_TEMPLATE/app-bug.yml
@@ -1,0 +1,70 @@
+name: Control app bug
+description: Report a problem with the MaD Control web app (opened pre-filled by the app's "Report a bug" button)
+title: "[app] "
+labels: ["bug", "app"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Most fields below are filled in for you by the app.
+
+        **Please attach the `mad-diagnostics-*.json` file the app just downloaded** —
+        drag it into the box at the bottom of this form. It carries the session log
+        (connection events, protocol traffic, errors, timings) and is what makes the
+        problem traceable without reproducing it.
+
+        It contains no sample values and no file contents. You are welcome to open it
+        and check before attaching.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What went wrong?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Connect
+        2. Run a test
+        3. Try to jog
+
+  - type: textarea
+    id: triage
+    attributes:
+      label: Summary
+      description: Computed by the app from the session log.
+      render: text
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      render: text
+
+  - type: textarea
+    id: counters
+    attributes:
+      label: Error counters
+      render: text
+
+  - type: textarea
+    id: errors
+    attributes:
+      label: Recent errors
+      render: text
+
+  - type: input
+    id: attachment
+    attributes:
+      label: Diagnostics file
+      description: The file the app downloaded. Attach it below.
+
+  - type: textarea
+    id: attachment_drop
+    attributes:
+      label: Attach the diagnostics file here
+      description: Drag and drop the `mad-diagnostics-*.json` file into this box.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,24 @@ jobs:
           npm run generate:proto
       - name: Verify (typecheck + lint + tests + build)
         run: npm run verify
+      # The unit tests cover the logging machinery; they cannot cover the
+      # instrumentation call sites, and the worker half (protocol frames,
+      # correlation ids, byte ring, batch transport) only runs with a device
+      # attached. This drives a scripted fake serial port instead, so unlike the
+      # SIL suite it needs no emulator or bridge — just Chrome and the dev
+      # server. Without it, a regression that silently empties a bug report
+      # would ship green.
+      - name: Diagnostics e2e (logging actually captures)
+        run: |
+          nohup npm run dev -- --host 127.0.0.1 --port 5174 > /tmp/mad-vite.log 2>&1 &
+          for i in $(seq 1 60); do
+            curl -sf http://127.0.0.1:5174 >/dev/null 2>&1 && break
+            sleep 1
+          done
+          curl -sf http://127.0.0.1:5174 >/dev/null 2>&1 || {
+            echo "=== vite log ==="; cat /tmp/mad-vite.log || true; exit 1
+          }
+          APP_URL=http://127.0.0.1:5174/ npm run e2e:diagnostics
       - name: Schema ↔ domain mapping lockstep (M12)
         working-directory: ${{ github.workspace }}
         run: |

--- a/Software/Control/docs/DIAGNOSTICS.md
+++ b/Software/Control/docs/DIAGNOSTICS.md
@@ -1,303 +1,32 @@
-# Diagnostics & user issue reporting — design
+# Diagnostics: what shipped
 
-Goal: when a user hits a bug, they press one button and I get enough to root-cause
-it without owning their machine — **including the bytes on the wire**. Frontend-only
-constraint holds throughout: no backend, no secrets, GitHub Pages deploy.
+The original plan here was a four-phase build. It was cut down, then most of the
+cut items were added back once the logging proved its worth. This records what
+exists and what is still deliberately out.
 
-## Why the current bundle isn't enough
+**Implemented** — see [LOGGING.md](LOGGING.md) for the detail:
 
-`src/diagnostics/` today produces a snapshot of *state at export time*: UA, build
-mode, capability flags, connection/firmware/port, worker counters, and a 1000-entry
-ring of five event tags (`connected`, `disconnected`, `device-error`, `timeout`,
-`nack`) recorded from `useStore.ts:301-334`.
+- Structured session log, merged across the main thread and the device worker
+- Raw 64 KiB serial byte tail with per-chunk metadata
+- Protocol, app, store, storage, UI, performance and **firmware-flash**
+  instrumentation
+- Correlation ids linking a user action to the frames it produced
+- Undecodable-traffic detection (the wrong-baud / bad-wiring case)
+- **IndexedDB persistence**, so a reload no longer destroys the evidence
+- **Computed triage summary** at the top of every bundle and issue
+- **Review-before-send preview** naming the identifying details being published
+- **`tools/view-diagnostics.mjs`** — timeline + annotated hex dump
+- E2E failure artifacts, plus a 9-check diagnostics suite gating CI
+- "Report a bug" → downloaded bundle + pre-filled GitHub issue
 
-That answers "what state was the app in." It cannot answer:
+**Still deliberately out:**
 
-- What bytes did the device actually send before the decode failed?
-- What did the user do in the minute before it broke?
-- Was the sample stream dropping, and by how much?
-- What threw, and from where?
-- Anything at all, if the page was reloaded after the freeze.
-
-Everything below is additive — the existing recorder becomes one source among many.
-
-## Architecture
-
-High-volume data (raw bytes, frames) **stays in the worker** and is pulled on demand
-at export/incident time. Low-volume data (breadcrumbs, errors) streams to the main
-thread on a 250 ms batch so there is one merged timeline. Nothing high-rate crosses
-the Comlink boundary continuously.
-
-```
-worker thread                          main thread
-  byteRing (256 KB, RX+TX) ──pull──▶
-  frameLog (ring, decoded)  ──pull──▶   bundle assembly ──▶ gzip ──▶ download
-  workerLog ───batch 250ms──────────▶   log (merged, monotonic)
-                                            ▲
-                                            ├── UI breadcrumbs (store actions)
-                                            ├── error capture (window/EB/console)
-                                            ├── health metrics
-                                            └── storage events
-                                            │
-                                            └──▶ IndexedDB (crash-survivable)
-```
-
-Timestamps: both threads record `performance.now()` plus a single shared epoch
-anchor captured at worker construction, so cross-thread ordering is real. Store
-`t` as ms-since-anchor (a small number) and resolve to wall clock only at export.
-
----
-
-## Layer 1 — capture
-
-### A. Raw serial byte tail — the highest-value item
-
-A preallocated circular `Uint8Array` in the worker holding the last ~60 s of traffic
-in both directions. This is what makes framing, CRC, baud, and partial-frame bugs
-diagnosable, which is the failure class real hardware actually produces.
-
-**New file: `src/diagnostics/byteRing.ts`**
-
-- `Uint8Array(256 * 1024)` + write head + wrapped flag.
-- Parallel chunk-metadata ring (~8192 entries): `{ at, dir: 'rx' | 'tx', start, len }`
-  so chunk boundaries and inter-chunk timing survive, not just a flat byte soup.
-- `push(dir, bytes)` is one `set()` memcpy + one metadata write. No allocation, no
-  GC pressure. Negligible next to the copy `feed_bytes()` already does.
-- `snapshot()` walks metadata oldest→newest and emits per-chunk **base64**
-  (base64 is 4/3 vs hex's 2× — matters before gzip, and a decode tool renders it).
-
-**Hook points (2 lines each):**
-
-| Where | Existing line | Add |
+| Not built | Why | What it would buy |
 | --- | --- | --- |
-| `DeviceSession.worker.ts:805` | `this.stats.bytesIn += value.length` | `byteRing.push('rx', value)` |
-| `DeviceSession.worker.ts:641` | `this.stats.bytesOut += out.length` | `byteRing.push('tx', out)` |
+| Incident freezing | Steady-state backoff took the ring from ~83 min to ~14 h, and persistence covers the crash case — the original motivation is largely gone | A pathologically chatty multi-day session still can't evict its own first failure |
+| `/diagnostics` viewer screen | The console mirror covers the maintainer, and the report preview now covers the user | Non-technical users could browse and filter the log in-app |
+| Gzip | Plain JSON is readable in any editor and the viewer handles the rest | Smaller attachments for very long sessions |
+| Serverless intake | Breaks the no-backend property; needs a deployed secret and abuse handling | True one-click filing, no GitHub account needed |
 
-Budget: 256 KB ring + ~320 KB metadata ≈ 600 KB resident. Cap is a constant.
-
-### B. Frame log
-
-Decoded frames with direction, command id + name, byte length, and — for non-sample
-frames — the decoded payload. Ring of ~2000 entries in the worker.
-
-The 100 Hz `MSG_READ_SAMPLE` / `MSG_READ_STATE` periodics are **counted and
-aggregated, not logged individually**; otherwise they'd evict everything interesting
-within seconds. A verbose toggle (below) turns on per-sample logging when chasing a
-specific sampling bug.
-
-Hook: `DeviceSession.worker.ts:615-637`, the loop that already walks polled events
-and bumps `this.stats`.
-
-### C. UI breadcrumbs
-
-Reconstructs what the user actually did. Instrument at the **store-action layer**
-(`src/store/useStore.ts`), not per component — the action list is already the
-complete set of user-initiated device operations:
-
-`connect` (381), `disconnect` (408), `reconnect` (422), `chooseDataFolder` (441),
-`grantDataFolder` (450), `saveConfig` (468), `saveSampleProfile` (483),
-`setMotionEnabled` (491), `emergencyStop` (492), `manualMove` (508), `homeAxis` (509),
-`zeroForce` (510), `zeroLength` (511), plus test start/stop and profile load.
-
-Plus route changes, from a small `useEffect` on `useLocation()` in `App.tsx`'s
-`Shell`. Log the action name and its scalar arguments (jog mm/speed, config field
-names) — never file contents.
-
-### D. Error capture
-
-Three sites already exist and currently dead-end at `console.error`:
-
-- `App.tsx:21-45` — `window.error` + `unhandledrejection`. The `report()` closure
-  already throttles and filters; add a `log()` call beside the existing
-  `console.error` + `notify`.
-- `ui/ErrorBoundary.tsx:37` — `componentDidCatch` already has an `onError` prop and
-  the component stack in hand. Pass a logging callback at both boundary sites in
-  `App.tsx`.
-- `device/session.ts` — `workerCrashEvents()` already models worker death; log it.
-
-Add: `console.error`/`console.warn` interception (wrap once at boot, forward to the
-real console), and WASM panic capture in the worker's existing `catch` at
-`DeviceSession.worker.ts:604`.
-
-### E. Health metrics
-
-Sampled ~1 Hz into the log, so degradation shows as a trend rather than a single
-number at export time:
-
-- Observed sample rate vs the profile's expected rate; sample sequence gaps.
-- `poll()` loop duration and tick overrun (the `TICK_MS` interval).
-- Write-chain depth (`writeChain` backlog), waiter count.
-- RX bytes/s, high-water chunk size.
-- Main-thread jank: long-task or rAF delta p95.
-- `performance.memory.usedJSHeapSize` where available (Chromium-only app, so it is).
-
-### F. Storage events
-
-`src/storage/DataStore.ts` — log directory chosen/restored, permission grant/deny,
-and each write as **name + byte count only**. Never contents. Wrap at the ~20 public
-async methods, or a single private helper they already funnel through.
-
----
-
-## Layer 2 — the unified log
-
-**New file: `src/diagnostics/log.ts`** — replaces `recorder.ts`.
-
-```ts
-type LogEntry = {
-  t: number;                    // ms since epoch anchor
-  level: 'debug' | 'info' | 'warn' | 'error';
-  cat: 'device' | 'proto' | 'ui' | 'store' | 'fs' | 'perf' | 'app';
-  tag: string;                  // short, groupable: 'connect', 'nack', 'jog'
-  msg?: string;
-  data?: Record<string, unknown>;  // scalars only
-};
-```
-
-Ring of ~5000, plus per-`tag` counters (keep the existing counter behaviour — it's
-genuinely useful for "how many nacks this session"). Subscriber list so the live
-viewer can tail it without polling.
-
-Two instances — one per thread. The worker's flushes over a new
-`onLogBatch` Comlink proxy (mirroring the existing `setEventSink` pattern at
-`DeviceSession.worker.ts:167`) every 250 ms or 100 entries, whichever first.
-
-## Layer 3 — persistence
-
-A freeze-then-reload currently destroys all evidence, which is exactly the case you
-most want. Append batched entries to **IndexedDB** (one store keyed by session id,
-retain the last 3 sessions, trim by age + count). Flush on `visibilitychange`.
-
-Note on the `src/` purity rule: this adds IndexedDB to the app's browser-API surface
-alongside Web Serial + File System Access. It is real app functionality, not a test
-fake, so the "fakes live in `e2e/`, never `src/`" rule is unaffected — but
-`CLAUDE.md`'s architecture section should be updated to name it.
-
-## Layer 4 — incidents
-
-A two-hour session evicts the interesting 30 seconds long before the user gets
-around to reporting. So: on `error` / `timeout` / `nack` / machine fault, freeze a
-copy of the preceding window — byte-ring snapshot, frame log tail, last ~200 log
-entries, current state — into an incident record. Cap at ~5 incidents (keep first 2
-and most recent 3; the *first* failure is usually the informative one).
-
-The freeze must happen **in the worker** for byte data, synchronously at detection.
-The main thread pulls incidents at export time.
-
-## Layer 5 — the viewer
-
-New route `/diagnostics` (`src/ui/screens/Diagnostics.tsx`), registered in
-`App.tsx:206-219` and code-split like the other non-landing screens. About keeps a
-one-line link and otherwise goes back to being About.
-
-- Live tail with filters by level/category/tag; pause-on-scroll.
-- Incident list, expandable to the frozen window with an annotated hex dump.
-- Counter table (nacks, timeouts, errors, bytes, uptime).
-- Verbosity toggle (`normal` / `verbose incl. per-sample frames`), persisted in
-  `localStorage`, surfaced in Settings too.
-- **"Report a problem"** button.
-
-## Layer 6 — the report flow
-
-Constraint: static PWA, nowhere to hide a token. So the flow is prefill + attach.
-
-**New file: `.github/ISSUE_TEMPLATE/app-bug.yml`** (repo has no templates yet) — an
-issue form with `id`s matching the prefill params: `summary`, `steps`, `app-version`,
-`fw-version`, `browser`, `counters`, plus a checkbox acknowledging the attachment.
-
-**New file: `src/diagnostics/report.ts`**
-
-1. User writes a short description + optional repro steps in a modal.
-2. Bundle is built, gzipped via `CompressionStream('gzip')`, downloaded as
-   `mad-diagnostics-<iso>.json.gz` (tens of KB with a full 60 s byte tail).
-3. Open `https://github.com/RileyMcCarthy/MaD/issues/new` with
-   `template=app-bug.yml&labels=bug,app&title=...` and the small scalar fields
-   prefilled. **Keep the URL under ~6 KB** — GitHub rejects much beyond 8 KB, so only
-   the summary goes in the URL; the log rides as the attachment. Assert this in a
-   unit test.
-4. The form body's final field tells them to drag the just-downloaded file in.
-5. Clipboard copy of the summary as an always-available fallback (and the only path
-   if they have no GitHub account).
-
-**New file: `tools/decode-diagnostics.mjs`** — CLI that takes the `.json.gz`,
-pretty-prints the merged timeline, and renders the byte ring as an annotated hex
-dump with inter-chunk deltas. This is what makes the base64 choice fine.
-
-Version stamping: `vite.config.ts` has no `define` block today. Add
-`__APP_VERSION__` (from `package.json`, currently `0.1.0`) and `__GIT_SHA__` so a
-report identifies an exact build. Declare both in `src/vite-env.d.ts`.
-
----
-
-## Privacy & redaction
-
-The bundle goes into a **public** GitHub issue, so the preview screen matters as much
-as the capture does. Show exactly what will be sent, with toggles.
-
-- Never: file contents, directory paths (basename only), clipboard, credentials.
-- Default off: raw byte ring (it's the most useful and the most opaque — make the
-  choice explicit rather than silent).
-- **Reversal of the current promise:** today's blurb advertises "no sample data."
-  For a debugging tool that's backwards — chasing a force-gauge glitch, the sample
-  values *are* the evidence. Make it an opt-in toggle ("include last 60 s of
-  samples", sourced from `liveBuffer`) shown in the preview.
-
-## Performance budget
-
-Non-negotiable: the ~100 Hz path must not regret this.
-
-- Byte ring: one memcpy + one metadata write per chunk. No allocation.
-- No per-sample log entries at default verbosity — counters only.
-- Nothing high-rate crosses Comlink; bytes are pulled on demand.
-- Log batching is time-sliced (250 ms), never per-event.
-- IndexedDB writes are batched and off the critical path.
-- Fixed memory ceiling: ~600 KB byte ring + ~1 MB logs. Assert in a test.
-
----
-
-## Work plan
-
-**P1 — capture foundation**
-- New `src/diagnostics/log.ts` (replaces `recorder.ts`), `byteRing.ts`, `frameLog.ts`,
-  `persist.ts` (IndexedDB), `anchor.ts` (shared epoch).
-- Worker: byte-ring + frame-log hooks (`:641`, `:805`, `:615-637`), `onLogBatch`
-  Comlink channel, batch flush timer.
-- Main: merged log, migrate the 5 `record()` calls in `useStore.ts:301-334`.
-- Tests: ring wrap, cross-thread ordering, memory ceiling, IDB retention.
-
-**P2 — sources**
-- Breadcrumbs across the store actions; route logging in `Shell`.
-- Error capture: `App.tsx:21-45`, `ErrorBoundary` `onError`, console interception,
-  worker crash + WASM panic.
-- Health metrics sampler; `DataStore` events.
-
-**P3 — incidents + viewer**
-- Worker-side incident freeze; pull API.
-- `/diagnostics` screen + route; Settings verbosity toggle; About trimmed to a link.
-- Update `e2e/capture-screenshots.mjs:292` (the comment and shot still assume the
-  export button lives on About).
-
-**P4 — report flow**
-- `report.ts`, the modal + preview with redaction toggles.
-- `.github/ISSUE_TEMPLATE/app-bug.yml`.
-- `vite.config.ts` version/SHA define + `vite-env.d.ts` types.
-- `tools/decode-diagnostics.mjs`.
-- README/user-guide: how to file a report.
-
-**Testing**
-- Vitest: ring wrap + eviction, redaction (assert no contents/paths leak), bundle
-  assembly, gzip round-trip, GitHub URL builder length cap, incident retention policy.
-- E2E against SIL: force a protocol error, export, assert the bundle contains the
-  offending frames and a non-empty byte tail.
-- `npm run verify` green throughout.
-
-## Open questions
-
-1. **Byte-ring default** — 60 s is a guess. If the bugs you're chasing are slow-burn
-   (drift over a long run) the tail wants to be sparse-but-long instead: keep full
-   fidelity for the last 10 s and 1-in-N sampling before that.
-2. **Sample inclusion** — opt-in toggle, or always include a decimated version
-   (say 1 Hz) since it's cheap and often the first thing you'd ask for?
-3. **Serverless intake** — deferred, not rejected. If the drag-and-drop step proves
-   to be where reports die, a Cloudflare Worker holding the token is the upgrade;
-   the bundle format wouldn't change.
+Serverless intake is the only one that would meaningfully change what a
+maintainer receives, and it costs the app its "no backend" property to get it.

--- a/Software/Control/docs/LOGGING.md
+++ b/Software/Control/docs/LOGGING.md
@@ -51,6 +51,15 @@ entries of the session with it.
 Per-`cat:tag` counters survive eviction, so "how many nacks this session" stays
 accurate over a long run.
 
+**Steady-state backoff.** The sample aggregator originally emitted every second,
+which meant healthy traffic alone evicted the entire ring in ~83 minutes of
+connected time — a long run would lose the connect sequence, the config and the
+test program. A heartbeat that only says "still fine" does not deserve that
+budget, so once the rate is steady it reports every 10 s instead
+(`AGGREGATE_STEADY_MS`). Anything abnormal, or a rate change over 20 %, reports
+immediately. That takes the ring from ~83 minutes to ~14 hours of healthy
+traffic.
+
 ## Runtime verbosity
 
 Console mirroring is controlled by two `localStorage` keys, read at boot and
@@ -73,14 +82,15 @@ defaults unless the main thread pushes a filter across.
 
 | Category | Covers |
 | --- | --- |
-| `app` | boot identity (version, git SHA, UA, capabilities, viewport), intercepted `console.error`/`warn`, global `error`/`unhandledrejection`, visibility and online/offline transitions |
+| `app` | boot identity (version, git SHA, UA, capabilities, viewport), intercepted `console.error`/`warn`, global `error`/`unhandledrejection`, visibility and online/offline transitions, main-thread stalls, heap growth |
 | `device` | port open with USB VID/PID, WASM init duration, connect/disconnect, link loss with counters, read/write stream failures, e-stop, worker crash |
-| `proto` | every non-periodic frame in and out by command **name**, acks, nacks, timeouts, round-trip durations, upload retries and failures |
+| `proto` | every non-periodic frame in and out by command **name**, acks, nacks, timeouts, round-trip durations, upload retries and failures, op start/end, test-run and download lifecycles |
 | `perf` | one aggregate per second for the ~100 Hz sample stream: rate, counts, throughput, last force/position, and anomalies |
-| `store` | user actions with their arguments *and outcomes*, machine-state transitions, faults, every toast shown |
+| `store` | user actions with their arguments *and outcomes*, field-level config diffs, machine-state transitions, faults, every toast shown |
 | `ui` | route changes, React render crashes with component stack |
 | `fs` | folder chosen/restored/permission, every DataStore op by name + duration, all failures |
 | `wasm` | protocol-core traps (`poll()` panics) |
+| `flash` | firmware programming: reset, boot-ROM detect attempts and replies, upload deciles, checksum verify, failure phase |
 
 ### Hot-path rules
 
@@ -89,6 +99,56 @@ feed `PeriodicAggregator`, which emits one summary per second and sanity-checks
 values (non-finite, out-of-range, physically impossible position jumps). A
 sample stream producing garbage is the bug; the frame that carried it is not
 interesting on its own.
+
+## Correlating an action with its frames
+
+Every serialized worker operation gets a monotonic id and bracketing
+`op-start` / `op-end` entries carrying the op name and duration. Frames emitted
+while it is in flight are tagged `op: <id>`, so a report reads
+
+```
+store/manualMove              { mm: 5, speed: 10 }
+proto/op-start  manualMove    { op: 7 }
+proto/tx        WRITE_MANUAL_MOVE(19)  { op: 7, bytes: 7 }
+proto/nack      WRITE_MANUAL_MOVE(19)  { op: 7 }
+proto/op-end    manualMove    { op: 7, ok: true, durMs: 12 }
+```
+
+instead of leaving the reader to guess which write a NACK belonged to.
+
+`runOp` already guarantees a single in-flight operation, so a plain field is a
+correct "current op" marker — no async-context plumbing. Poll-driven traffic can
+still interleave, so an inbound frame is only tagged when its command matches
+the command the op actually wrote (`claimOpCommand`). The store-side action and
+the worker-side op are joined by name and adjacency in the merged timeline
+rather than by a shared id, since threading one through Comlink would mean
+changing every method signature.
+
+## Test runs and downloads
+
+A run logs `test-program` before uploading: line count, byte size, an FNV-1a
+content hash, a per-opcode histogram, and `endsWithG122`. That last flag makes
+the project's classic footgun visible at a glance — a program without its
+trailing `G122` never signals completion to the firmware. The hash answers "did
+these two runs upload the same thing", which catches a non-deterministic
+transform.
+
+Then `test-uploaded` (duration), `test-started` (accepted by the device), or
+`test-failed` — which records whether the partial SD file was invalidated,
+because that decides whether a retry is safe or runs a half-written program.
+`upload-aborted` reports how many batches and bytes made it out before a
+failure.
+
+Downloads log `download-start` / `download-done` / `download-failed` with
+request count, bytes, duration, and **NACK retries** — a download that succeeded
+after 40 BUSY NACKs is a bug report waiting to happen and is otherwise silent.
+
+## Decode failures carry their bytes
+
+A protocol `error` event and a WASM `poll-trap` both attach `tail`: a hex dump
+of the last 64 (or 96) bytes from the byte ring, inline in the entry. For a
+framing or CRC fault those bytes are the whole story, and by export time they
+would long since have been overwritten.
 
 ## Raw serial tail
 
@@ -125,7 +185,154 @@ touching any of the ~40 scenario bodies. On failure `run-all.mjs` writes
 and prints the last 25 entries to stderr. Browser console output is captured
 separately, since a failure before boot never reaches the in-page logger.
 
+The runner calls `setCurrentScenario(id)` before each scenario and
+`connectToSil` drops a `scenario <id>` marker into the app's timeline at the
+first point the page can take one, so a dump shows which scenario produced
+which frames.
+
 `e2e/artifacts/` is gitignored.
+
+## Verifying the logging actually works
+
+The unit tests cover the logging *machinery*. They cannot cover the ~64
+instrumentation call sites, and the entire worker half — protocol frames,
+correlation ids, the byte ring, the worker→main batch transport — only runs
+with a device attached. That is exactly the half a bug report depends on.
+
+```bash
+npm run dev              # in one terminal
+npm run e2e:diagnostics  # in another
+```
+
+`e2e/diagnostics-smoke.mjs` injects a **scripted fake serial port** rather than
+using SIL, so it needs no emulator or bridge and can drive failure modes an
+emulator makes awkward. Two device behaviours:
+
+- **silent** — accepts writes, never replies. Exercises outbound frame logging,
+  op bracketing, correlation ids and the timeout path.
+- **garbage** — streams deterministic non-frame bytes, which is what a wrong
+  baud rate, a noisy cable or a half-flashed board actually looks like.
+
+It asserts what a maintainer needs to be true: worker entries reach the merged
+timeline and it is time-ordered; outbound frames are named and sized; ops are
+bracketed and their frames carry the op id; an unresponsive device produces
+warnings rather than silence; garbage produces an entry carrying a hex byte
+tail; and the exported bundle contains build identity, a non-empty log, RX
+chunks and worker counters.
+
+This check found three real defects that the unit tests and a manual browser
+pass both missed: read requests produced no `tx` entry at all, garbled traffic
+produced no log entry whatsoever, and every read frame was labelled with a
+*write* command name.
+
+### Command ids are direction-scoped
+
+Reads and writes share the id space — `READ_MACHINE_CONFIGURATION` and
+`WRITE_TEST_RUN` are both command `2`, `READ_STATE` and `WRITE_MOTION_ENABLE`
+are both `1`. A single id→name map silently mislabels half the traffic, so
+`commandName(id, dir)` takes the direction the call site knows. Where direction
+genuinely is not knowable — an inbound frame whose id does not match the
+in-flight op — it renders `READ_STATE|WRITE_MOTION_ENABLE(1)`. A confidently
+wrong name is worse in a bug report than a hedged one.
+
+Note that `isPeriodicCommand` is only consulted for `data` events, which is what
+keeps write acks for ids 0 and 1 from being swallowed as periodics.
+
+### Undecodable traffic
+
+The protocol core silently discards bytes that are not valid frames, so a wrong
+baud rate used to produce a stream of received bytes and *no* log entry at all —
+the app simply looked dead. A watchdog now warns (twice, then stops) when a
+2 s window carries bytes but decodes nothing, attaching a hex tail. It compares
+*decoded frames*, not events, so the timeouts a garbled link generates cannot
+placate it.
+
+## Firmware flashing
+
+Programming runs against the P2 **boot ROM**, not the MaD protocol, so none of
+the `proto` instrumentation covers it — and it is the longest, most
+failure-prone serial operation in the app. `program.ts` logs the whole run:
+reset, each detect attempt with what the ROM actually replied, upload start and
+deciles, checksum verification, and on failure **which phase it died in**.
+Reset/detect points at wiring or a busy port, upload at the link, verify at
+dropped bytes.
+
+`p2loader.ts` stays dependency-free — it is shared with `tools/hw-p2load.mts`,
+which drives the identical protocol headlessly — so it emits a typed
+`LoaderEvent` and the orchestrator decides what to log.
+
+## Surviving a reload
+
+`src/diagnostics/persist.ts` mirrors the merged timeline into **IndexedDB** as
+it is produced. Without it the case people most often report — "it froze so I
+restarted it" — destroys the only evidence of what went wrong.
+
+The last **3** sessions are retained, **2000** entries each (the tail, since
+after a crash the last entries are the interesting ones). Writes are buffered
+and flushed every 5 s plus on `visibilitychange`, which is the last reliable
+moment before a tab is discarded. Every IndexedDB call is best-effort: a denied
+quota or private mode degrades to "no persistence", never an error.
+
+A bundle attaches the previous session automatically as `previousSession`. Its
+`closed: false` means that session never shut down cleanly — itself a strong
+signal.
+
+## Triage summary
+
+`src/diagnostics/triage.ts` computes a verdict from the log and puts it at the
+top of every bundle, so a maintainer does not have to read 5000 entries to learn
+whether the link ever worked. It reports the first error *and* the last (the
+first is usually the cause, the last usually a symptom), ranks failure counters,
+and raises actionable flags — never connected, connected but silent, undecodable
+traffic, WASM trap, render crash, failed flash, main-thread stall, truncated
+log. The same text goes into the issue body.
+
+## Reporting a bug
+
+`src/diagnostics/report.ts` turns a session into a filed GitHub issue. There is
+no backend and nowhere to hide a token, so the flow is two steps with zero
+infrastructure:
+
+0. **Review first.** `buildReportPreview` produces the real bundle and lists
+   what it contains and which identifying details it carries (browser and OS,
+   the adapter's USB id, data-folder names, raw bytes). This becomes a public
+   issue, so a checkbox is not informed consent — the user sees the actual
+   contents. `fileBugReport` then publishes *the reviewed bundle*, not a
+   freshly-built one, so what ships is what was seen.
+1. The bundle downloads locally as `mad-diagnostics-<iso>.json`.
+2. A pre-filled issue opens against `RileyMcCarthy/MaD` using the
+   `.github/ISSUE_TEMPLATE/app-bug.yml` form, which the user submits under their
+   own account with the file attached.
+
+The download happens **first**, so a blocked pop-up never loses the report — the
+user still has the file, and the UI shows the issue link as a fallback.
+
+Only a compact summary rides in the URL: build identity, firmware version,
+failure-ish counters, and the last five error entries. GitHub rejects very long
+URLs, so `buildIssueUrl` enforces a 6 KB budget, trimming derived blocks
+(`errors`, `counters`, `environment`) before anything the user typed and
+truncating the summary only as a last resort. A long session therefore cannot
+silently produce a dead link — asserted in tests.
+
+`fileBugReport` imports `exportBundle` at call time rather than module scope,
+because that module reaches the device client, which constructs a `Worker` on
+import. Keeping it out of the static graph leaves the URL and field builders
+pure and unit-testable.
+
+## Reading a bundle
+
+```bash
+node tools/view-diagnostics.mjs report.json            # summary + timeline
+node tools/view-diagnostics.mjs report.json --bytes    # annotated hex dump
+node tools/view-diagnostics.mjs report.json --level warn --cat proto,flash
+node tools/view-diagnostics.mjs report.json --previous # the pre-reload session
+```
+
+The bundle is built to be complete, not readable. The viewer renders the triage
+summary, a filterable merged timeline, and — the part that is otherwise
+unusable — a hex dump of the serial window with **inter-chunk timing**, because
+a frame split across two reads with a pause between them looks nothing like one
+that arrived whole.
 
 ## Build identity
 

--- a/Software/Control/e2e/diagnostics-smoke.mjs
+++ b/Software/Control/e2e/diagnostics-smoke.mjs
@@ -1,0 +1,358 @@
+/**
+ * Diagnostics end-to-end check — does a bug report actually show what happened?
+ *
+ * The unit tests cover the logging *machinery* (ring, sanitizer, byte ring, URL
+ * builder). They cannot cover the ~64 instrumentation call sites, and the entire
+ * worker half — protocol frames, correlation ids, the byte ring, the
+ * worker→main batch transport — only ever runs with a device attached. That is
+ * precisely the half a bug report depends on, so it needs its own check.
+ *
+ * Deliberately does NOT need the SIL emulator or the WS bridge: it injects a
+ * scripted fake serial port instead. That keeps it runnable anywhere (and in
+ * CI), and lets it drive failure modes an emulator makes awkward — notably a
+ * device that returns pure garbage, which is the decode-failure path where the
+ * raw byte tail earns its place.
+ *
+ *   node e2e/diagnostics-smoke.mjs        # needs only `npm run dev`
+ */
+
+import { chromium, installOpfsDataDir, OPFS_DIR } from './fixtures.mjs';
+
+const APP_URL = process.env.APP_URL || 'http://localhost:5174/';
+const HEADED = process.env.HEADED === '1';
+
+/**
+ * Injected before app code. A `navigator.serial` whose port behaves per `mode`:
+ *
+ *   'silent'  — accepts writes, never replies. Drives the timeout path and lets
+ *               outbound frame logging be observed in isolation.
+ *   'garbage' — streams bytes that are not valid frames, which is what a wrong
+ *               baud, a half-flashed board or a noisy cable actually looks like.
+ */
+function installScriptedSerial(mode) {
+  let controller = null;
+  let timer = null;
+  const port = {
+    async open() {
+      port.__written = [];
+      const readable = new ReadableStream({
+        start(c) {
+          controller = c;
+        },
+        cancel() {
+          if (timer) clearInterval(timer);
+        },
+      });
+      const writable = new WritableStream({
+        write(chunk) {
+          port.__written.push(Array.from(chunk));
+        },
+      });
+      port.__readable = readable;
+      port.__writable = writable;
+      if (mode === 'garbage') {
+        // Deterministic non-frame bytes: reproducible failures beat random ones.
+        let n = 0;
+        timer = setInterval(() => {
+          const buf = new Uint8Array(32);
+          for (let i = 0; i < buf.length; i++) buf[i] = (n * 31 + i * 7) & 0xff;
+          n += 1;
+          try {
+            controller.enqueue(buf);
+          } catch {
+            /* closed */
+          }
+        }, 50);
+      }
+    },
+    get readable() {
+      return port.__readable;
+    },
+    get writable() {
+      return port.__writable;
+    },
+    getInfo() {
+      return { usbVendorId: 0x0403, usbProductId: 0x6001 };
+    },
+    async close() {
+      if (timer) clearInterval(timer);
+    },
+    addEventListener() {},
+    removeEventListener() {},
+  };
+  Object.defineProperty(navigator, 'serial', {
+    configurable: true,
+    value: {
+      requestPort: async () => port,
+      getPorts: async () => [port],
+      addEventListener() {},
+      removeEventListener() {},
+    },
+  });
+}
+
+const snapshot = (page) => page.evaluate(() => globalThis.__madLog?.snapshot() ?? null);
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg);
+}
+
+/** Entries matching a `cat/tag`. */
+const byTag = (log, cat, tag) => log.entries.filter((e) => e.cat === cat && e.tag === tag);
+
+async function openApp(mode) {
+  const browser = await chromium.launch({ channel: 'chrome', headless: !HEADED });
+  const page = await browser.newPage();
+  await page.addInitScript(installScriptedSerial, mode);
+  await page.addInitScript(installOpfsDataDir, OPFS_DIR);
+  await page.goto(`${APP_URL}#/connect`);
+  await page.getByTestId('connect-device').click();
+  return { browser, page };
+}
+
+const results = [];
+async function scenario(name, fn) {
+  process.stdout.write(`• ${name} … `);
+  try {
+    await fn();
+    console.log('✅');
+    results.push(true);
+  } catch (err) {
+    console.log(`❌ ${err.message}`);
+    results.push(false);
+  }
+}
+
+async function main() {
+  try {
+    const res = await fetch(APP_URL);
+    if (!res.ok) throw new Error(String(res.status));
+  } catch {
+    console.error(`✗ App not reachable at ${APP_URL}. Start it with: npm run dev`);
+    process.exit(2);
+  }
+
+  // ── The worker half exists at all ───────────────────────────────────────────
+  await scenario('worker entries reach the merged timeline', async () => {
+    const { browser, page } = await openApp('silent');
+    try {
+      await page.waitForTimeout(3000);
+      const log = await snapshot(page);
+      assert(log !== null, 'no __madLog hook on the page');
+      const worker = log.entries.filter((e) => e.thread === 'worker');
+      assert(worker.length > 0, 'no worker-thread entries — the batch transport is not delivering');
+      const main = log.entries.filter((e) => e.thread === 'main');
+      assert(main.length > 0, 'no main-thread entries');
+      // Both threads anchor to wall clock; if that were wrong the merge would
+      // interleave nonsensically and every report would be unreadable.
+      const sorted = log.entries.every((e, i, a) => i === 0 || a[i - 1].t <= e.t);
+      assert(sorted, 'merged timeline is not time-ordered across threads');
+    } finally {
+      await browser.close();
+    }
+  });
+
+  // ── Outbound protocol traffic is legible ───────────────────────────────────
+  await scenario('protocol writes are logged by command name', async () => {
+    const { browser, page } = await openApp('silent');
+    try {
+      await page.waitForTimeout(3000);
+      const log = await snapshot(page);
+      const tx = byTag(log, 'proto', 'tx');
+      assert(tx.length > 0, 'no proto/tx entries — outbound frames are invisible');
+      const named = tx.filter((e) => /^[A-Z_]+\(\d+\)$/.test(e.msg ?? ''));
+      assert(named.length > 0, `tx entries are not named: ${JSON.stringify(tx[0])}`);
+      assert(
+        tx.every((e) => typeof e.data?.bytes === 'number' || e.data?.kind === 'read'),
+        'a tx entry is neither sized nor marked as a read',
+      );
+      // Reads and writes share the protocol id space, so a name resolved
+      // without direction is not merely vague — it is wrong. A read must never
+      // be reported under a WRITE_ name.
+      const misnamed = tx.filter((e) => e.data?.kind === 'read' && /^WRITE_/.test(e.msg ?? ''));
+      assert(misnamed.length === 0, `read frames labelled as writes: ${misnamed.map((e) => e.msg).join(', ')}`);
+      // And the op's own name must agree with the frame it sent.
+      const starts = byTag(log, 'proto', 'op-start');
+      for (const s of starts.filter((e) => /^read[A-Z]/.test(e.msg ?? ''))) {
+        const frame = tx.find((e) => e.data?.op === s.data?.op);
+        assert(
+          frame === undefined || /^READ_/.test(frame.msg ?? ''),
+          `op ${s.msg} sent a frame named ${frame?.msg}`,
+        );
+      }
+    } finally {
+      await browser.close();
+    }
+  });
+
+  // ── Correlation: an action's frames can be traced back to it ───────────────
+  await scenario('ops are bracketed and their frames carry the op id', async () => {
+    const { browser, page } = await openApp('silent');
+    try {
+      await page.waitForTimeout(3000);
+      const log = await snapshot(page);
+      const starts = byTag(log, 'proto', 'op-start');
+      assert(starts.length > 0, 'no op-start entries — nothing is correlated');
+      assert(starts.every((e) => typeof e.data?.op === 'number'), 'op-start lacks an op id');
+      const tagged = byTag(log, 'proto', 'tx').filter((e) => typeof e.data?.op === 'number');
+      assert(tagged.length > 0, 'no tx frame carries an op id');
+      // The op id must actually match one that was opened, or correlation is noise.
+      const ids = new Set(starts.map((e) => e.data.op));
+      assert(tagged.every((e) => ids.has(e.data.op)), 'a tx frame references an unknown op id');
+    } finally {
+      await browser.close();
+    }
+  });
+
+  // ── A device that never answers is diagnosable ─────────────────────────────
+  await scenario('an unresponsive device produces timeouts, not silence', async () => {
+    const { browser, page } = await openApp('silent');
+    try {
+      await page.waitForTimeout(7000);
+      const log = await snapshot(page);
+      const timeouts = byTag(log, 'proto', 'timeout');
+      const failed = log.entries.filter((e) => e.level === 'error' || e.level === 'warn');
+      assert(
+        timeouts.length > 0 || failed.length > 0,
+        'a device that never replies produced no warning at all',
+      );
+    } finally {
+      await browser.close();
+    }
+  });
+
+  // ── The decode-failure path, where the byte tail earns its place ───────────
+  await scenario('garbage on the wire is captured with its bytes', async () => {
+    const { browser, page } = await openApp('garbage');
+    try {
+      await page.waitForTimeout(6000);
+      const log = await snapshot(page);
+      const withTail = log.entries.filter((e) => typeof e.data?.tail === 'string' && e.data.tail !== '');
+      assert(
+        withTail.length > 0,
+        'garbage produced no entry carrying a byte tail — a framing bug would be undiagnosable',
+      );
+      const tail = withTail[0].data.tail;
+      assert(/^([0-9a-f]{2} )*[0-9a-f]{2}$/.test(tail), `tail is not a hex dump: ${tail}`);
+    } finally {
+      await browser.close();
+    }
+  });
+
+  // ── Detection must survive a reconnect, not just the first session ─────────
+  await scenario('a reconnected session still detects garbage', async () => {
+    const { browser, page } = await openApp('garbage');
+    try {
+      await page.waitForTimeout(8000);
+      const first = (await snapshot(page)).entries.filter((e) => e.tag === 'undecodable').length;
+      assert(first > 0, 'no undecodable warning in the first session');
+
+      // Reconnecting tears down and recreates the worker, so this covers the
+      // whole second-session path: fresh WASM instance, fresh byte ring, fresh
+      // batch transport. A user who unplugs and replugs must not end up with a
+      // silently undiagnosable session.
+      await page.evaluate(() => globalThis.__madLog.clear());
+      await page.goto(`${APP_URL}#/connect`);
+      await page.getByRole('button', { name: /^Disconnect$/ }).click();
+      await page.getByTestId('connect-device').waitFor({ timeout: 8000 });
+      await page.getByTestId('connect-device').click();
+      await page.waitForTimeout(8000);
+
+      const second = (await snapshot(page)).entries.filter((e) => e.tag === 'undecodable').length;
+      assert(second > 0, 'reconnected session produced no undecodable warning');
+    } finally {
+      await browser.close();
+    }
+  });
+
+  // ── The artifact a maintainer actually receives ────────────────────────────
+  await scenario('the exported bundle contains the wire bytes', async () => {
+    const { browser, page } = await openApp('garbage');
+    try {
+      await page.waitForTimeout(4000);
+      const bundle = await page.evaluate(async () => {
+        const mod = await import('/src/diagnostics/exportBundle.ts');
+        return mod.buildDiagnosticsBundle({ includeSerialTail: true });
+      });
+      assert(bundle.version !== 'unknown', 'bundle has no build version');
+      assert(bundle.gitSha !== 'unknown', 'bundle has no git sha');
+      assert(bundle.log.entries.length > 0, 'bundle carries an empty log');
+      assert(bundle.serialTail, 'bundle has no serial tail despite being asked for one');
+      assert(bundle.serialTail.chunks.length > 0, 'serial tail has no chunks');
+      assert(bundle.serialTail.totalRxBytes > 0, 'serial tail recorded no received bytes');
+      const rx = bundle.serialTail.chunks.filter((c) => c.dir === 'rx');
+      assert(rx.length > 0, 'no RX chunks captured');
+      assert(typeof rx[0].b64 === 'string' && rx[0].b64.length > 0, 'RX chunk carries no payload');
+      // Worker counters must survive into the bundle too.
+      assert(bundle.worker && typeof bundle.worker.bytesIn === 'number', 'bundle lacks worker counters');
+      assert(bundle.worker.bytesIn > 0, 'worker reports no bytes in despite a talking device');
+    } finally {
+      await browser.close();
+    }
+  });
+
+  // ── The bundle leads with a usable verdict ─────────────────────────────────
+  await scenario('the bundle carries an accurate triage summary', async () => {
+    const { browser, page } = await openApp('garbage');
+    try {
+      await page.waitForTimeout(6000);
+      const bundle = await page.evaluate(async () => {
+        const mod = await import('/src/diagnostics/exportBundle.ts');
+        return mod.buildDiagnosticsBundle({ includeSerialTail: false });
+      });
+      const t = bundle.triage;
+      assert(t, 'bundle has no triage summary');
+      assert(typeof t.headline === 'string' && t.headline.length > 0, 'triage has no headline');
+      assert(t.everConnected === true, 'triage says never connected, but the app connected');
+      // A garbled link is the scenario; the summary must actually name it.
+      assert(t.undecodableTraffic === true, 'triage missed the undecodable traffic');
+      assert(
+        t.flags.some((f) => /baud rate, wiring, or firmware/.test(f)),
+        `triage flags lack an actionable hint: ${JSON.stringify(t.flags)}`,
+      );
+      assert(t.firstError, 'triage has no first error despite errors being logged');
+    } finally {
+      await browser.close();
+    }
+  });
+
+  // ── A reload must not destroy the evidence ─────────────────────────────────
+  await scenario('the previous session survives a reload', async () => {
+    const { browser, page } = await openApp('garbage');
+    try {
+      await page.waitForTimeout(5000);
+      const before = await snapshot(page);
+      assert(before.entries.length > 0, 'nothing logged before the reload');
+
+      // The case people actually report: it froze, so they restarted it.
+      await page.reload();
+      await page.goto(`${APP_URL}#/connect`);
+      const connect = page.getByTestId('connect-device');
+      if (await connect.count()) await connect.click().catch(() => {});
+      await page.waitForTimeout(6000);
+
+      const bundle = await page.evaluate(async () => {
+        const mod = await import('/src/diagnostics/exportBundle.ts');
+        return mod.buildDiagnosticsBundle({ includeSerialTail: false });
+      });
+      const prev = bundle.previousSession;
+      assert(prev, 'the pre-reload session was lost — a report after a reload has no evidence');
+      assert(prev.entries.length > 0, 'the persisted previous session is empty');
+      assert(prev.id !== bundle.sessionId, 'previous session id equals the current one');
+      // An unclean end is itself diagnostic, so it must be recorded as such.
+      assert(prev.closed === false, 'a session killed by reload was recorded as cleanly closed');
+    } finally {
+      await browser.close();
+    }
+  });
+
+  const passed = results.filter(Boolean).length;
+  console.log(`\n${passed}/${results.length} diagnostics checks passed`);
+  if (passed !== results.length) process.exit(1);
+  console.log('✅ a bug report from this build would show what happened');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/Software/Control/e2e/fixtures.mjs
+++ b/Software/Control/e2e/fixtures.mjs
@@ -289,9 +289,20 @@ export async function dumpFailureArtifacts(scenario, err) {
   return file;
 }
 
+/**
+ * Name the scenario now running, so every app-side log entry it produces sits
+ * under a visible boundary in the dump.
+ */
+let currentScenario = null;
+export function setCurrentScenario(id) {
+  currentScenario = id;
+}
+
 /** Connect the app to SIL via the UI (call after navigating to the app). */
 export async function connectToSil(page) {
   await page.goto(`${APP_URL}#/connect`);
+  // First point at which the app is loaded and can take a marker.
+  if (currentScenario !== null) await markAppLog(page, `scenario ${currentScenario}`);
   // The primary button (testid connect-device) prompts requestPort() → our fake.
   await page.getByTestId('connect-device').click();
   // Wait until the store reports connected — the status dot gets `.connected`.

--- a/Software/Control/e2e/run-all.mjs
+++ b/Software/Control/e2e/run-all.mjs
@@ -24,6 +24,7 @@ import {
   connectToSil,
   chooseDataFolder,
   dumpFailureArtifacts,
+  setCurrentScenario,
   installFakeBootRom,
   installOpfsDataDir,
   OPFS_DIR,
@@ -1528,6 +1529,7 @@ async function main() {
   const failures = [];
   for (const s of selected) {
     process.stdout.write(`• ${s.id} ${s.name} … `);
+    setCurrentScenario(s.id);
     try {
       // eslint-disable-next-line no-await-in-loop
       await s.run();

--- a/Software/Control/package.json
+++ b/Software/Control/package.json
@@ -21,6 +21,7 @@
     "e2e:smoke": "node e2e/run-smoke.mjs",
     "hw:flash": "vite-node tools/hw-p2load.mts --",
     "sil:bridge": "node tools/sil-ws-bridge.mjs",
+    "e2e:diagnostics": "node e2e/diagnostics-smoke.mjs",
     "sil:smoke": "node e2e/sil-smoke.mjs",
     "sil:app": "node e2e/sil-playground.mjs",
     "docs:screenshots": "node e2e/capture-screenshots.mjs"

--- a/Software/Control/src/device/DeviceSession.worker.ts
+++ b/Software/Control/src/device/DeviceSession.worker.ts
@@ -15,7 +15,7 @@ import init, { WasmClient } from '@/wasm/protoemb_runtime.js';
 import wasmUrl from '@/wasm/protoemb_runtime_bg.wasm?url';
 import { logger, setLogSink, flushLog, nowMs, type LogBatchSink } from '@/diagnostics/log';
 import { byteRing } from '@/diagnostics/byteRing';
-import { commandName, isPeriodicCommand } from './commandNames';
+import { commandName, isPeriodicCommand, summariseGcode, type CommandDir } from './commandNames';
 import {
   decodeSample,
   decodeMachineState,
@@ -128,6 +128,18 @@ const logPerf = logger('perf');
 
 /** How often the periodic sample/state traffic is summarised into the log. */
 const AGGREGATE_INTERVAL_MS = 1000;
+/**
+ * How often a *healthy* stream reports in.
+ *
+ * At one entry per second the 5000-entry ring holds only ~83 minutes of
+ * connected time, so a long run silently evicts the connect sequence, the
+ * config and the test program — exactly the context a report needs. A heartbeat
+ * that only says "still fine" does not deserve that budget, so once the rate is
+ * steady it backs off to this. Anything abnormal reports immediately.
+ */
+const AGGREGATE_STEADY_MS = 10_000;
+/** Rate change (as a fraction) that counts as worth reporting early. */
+const AGGREGATE_RATE_DELTA = 0.2;
 
 /**
  * Rolls the ~100 Hz periodic traffic up into one entry per second.
@@ -152,6 +164,37 @@ class PeriodicAggregator {
   private lastForce = Number.NaN;
 
   private lastPosition = Number.NaN;
+
+  /** When a healthy summary last reached the log, and at what rate. */
+  private reportedAt = 0;
+
+  private reportedRate = Number.NaN;
+
+  /**
+   * Report a healthy window only when it is the first one, when the rate has
+   * moved materially, or when the steady-state interval has elapsed. A stream
+   * holding a constant rate is the case that must not consume the ring.
+   */
+  private shouldReport(now: number, rateHz: number): boolean {
+    if (this.reportedAt === 0) return true;
+    if (now - this.reportedAt >= AGGREGATE_STEADY_MS) return true;
+    if (!Number.isFinite(this.reportedRate)) return true;
+    const base = Math.max(this.reportedRate, 1);
+    return Math.abs(rateHz - this.reportedRate) / base >= AGGREGATE_RATE_DELTA;
+  }
+
+  /**
+   * Clear per-session state as well as the window.
+   *
+   * `reset()` runs after every window, so the backoff bookkeeping deliberately
+   * survives it — otherwise a healthy stream would report every second forever.
+   * A new connection is different: its first window should always be recorded.
+   */
+  resetSession(): void {
+    this.reportedAt = 0;
+    this.reportedRate = Number.NaN;
+    this.reset();
+  }
 
   reset(): void {
     this.windowStart = nowMs();
@@ -213,8 +256,12 @@ class PeriodicAggregator {
           anomalies: this.anomalies,
           firstAnomaly: this.firstAnomaly,
         });
-      } else {
+        this.reportedAt = now;
+        this.reportedRate = rateHz;
+      } else if (this.shouldReport(now, rateHz)) {
         logPerf.debug('stream', undefined, data);
+        this.reportedAt = now;
+        this.reportedRate = rateHz;
       }
     }
     const carryForce = this.lastForce;
@@ -256,6 +303,28 @@ class DeviceSession {
    *  command). Periodic sample/state reads are Rust-driven and don't use this. */
   private opChain: Promise<unknown> = Promise.resolve();
 
+  /** Monotonic id for correlating a user action with the frames it produced. */
+  private opSeq = 0;
+
+  /** Undecodable-traffic watchdog: bytes/decoded frames seen at the last check.
+   *  Needs no per-connect reset — `DeviceClient.connect()` recreates the worker,
+   *  so every session starts from a fresh instance with these at zero. */
+  private gibberishAt = 0;
+
+  private gibberishBytes = 0;
+
+  private gibberishEvents = 0;
+
+  /** Warnings already emitted, so a persistently wrong link warns twice, not forever. */
+  private gibberishWarnings = 0;
+
+  private activeOp: {
+    id: number;
+    name: string;
+    command: number | null;
+    dir: CommandDir | null;
+  } | null = null;
+
   private lastSample: SampleData | null = null;
 
   /** Lightweight throughput/error counters for the diagnostics bundle. */
@@ -264,6 +333,7 @@ class DeviceSession {
     bytesIn: 0,
     bytesOut: 0,
     events: 0,
+    decoded: 0,
     errors: 0,
     timeouts: 0,
     nacks: 0,
@@ -305,18 +375,18 @@ class DeviceSession {
       bytesIn: 0,
       bytesOut: 0,
       events: 0,
+      decoded: 0,
       errors: 0,
       timeouts: 0,
       nacks: 0,
       lastError: '',
       lastErrorAt: 0,
     };
-
     this.client.register_periodic(MSG_READ_SAMPLE, MSG_SAMPLE_PERIOD_MS, SAMPLE_STORAGE_COUNT);
     this.client.register_periodic(MSG_READ_STATE, MSG_STATE_PERIOD_MS, STATE_STORAGE_COUNT);
 
     byteRing.reset();
-    this.periodic.reset();
+    this.periodic.resetSession();
     logDev.info('connect', 'session started', {
       responseTimeoutMs: opts.responseTimeoutMs ?? 2000,
       samplePeriodMs: MSG_SAMPLE_PERIOD_MS,
@@ -486,35 +556,35 @@ class DeviceSession {
   async readMachineConfiguration(): Promise<MachineConfiguration> {
     return this.runOp(async () => {
       const p = this.waitFor((e) => e.kind === 'configuration', 3000, 'configuration', MSG_READ_MACHINE_CONFIGURATION);
-      this.client?.read(MSG_READ_MACHINE_CONFIGURATION, true, undefined);
+      this.requestRead(MSG_READ_MACHINE_CONFIGURATION);
       const e = await p;
       return (e as Extract<DeviceEvent, { kind: 'configuration' }>).data;
-    });
+    }, 'readMachineConfiguration');
   }
 
   async readSampleProfile(): Promise<SampleProfile> {
     return this.runOp(async () => {
       const p = this.waitFor((e) => e.kind === 'sampleProfile', 3000, 'sampleProfile', MSG_READ_SAMPLE_PROFILE);
-      this.client?.read(MSG_READ_SAMPLE_PROFILE, true, undefined);
+      this.requestRead(MSG_READ_SAMPLE_PROFILE);
       const e = await p;
       return (e as Extract<DeviceEvent, { kind: 'sampleProfile' }>).data;
-    });
+    }, 'readSampleProfile');
   }
 
   async readFirmwareVersion(): Promise<string> {
     return this.runOp(async () => {
       const p = this.waitFor((e) => e.kind === 'firmwareVersion', 3000, 'firmwareVersion', MSG_READ_FIRMWARE_VERSION);
-      this.client?.read(MSG_READ_FIRMWARE_VERSION, true, undefined);
+      this.requestRead(MSG_READ_FIRMWARE_VERSION);
       const e = await p;
       return (e as Extract<DeviceEvent, { kind: 'firmwareVersion' }>).data.version;
-    });
+    }, 'readFirmwareVersion');
   }
 
   // ── High-level writes (command → ACK) ──
 
   async writeMachineConfiguration(config: MachineConfiguration): Promise<boolean> {
     const bytes = encodeMachineConfiguration(configFromShared(config));
-    return this.runOp(() => this.writeAndAck(MSG_WRITE_MACHINE_CONFIGURATION_WRITE, bytes, 3000));
+    return this.runOp(() => this.writeAndAck(MSG_WRITE_MACHINE_CONFIGURATION_WRITE, bytes, 3000), 'writeMachineConfiguration');
   }
 
   async writeSampleProfile(profile: SampleProfile): Promise<boolean> {
@@ -527,12 +597,13 @@ class DeviceSession {
       serial: profile.serial ?? '',
     };
     const bytes = encodeSampleProfile(sampleProfileFromShared(firmwareProfile));
-    return this.runOp(() => this.writeAndAck(MSG_WRITE_SAMPLE_PROFILE_WRITE, bytes, 2000));
+    return this.runOp(() => this.writeAndAck(MSG_WRITE_SAMPLE_PROFILE_WRITE, bytes, 2000), 'writeSampleProfile');
   }
 
   async setMotionEnabled(enabled: boolean): Promise<boolean> {
-    return this.runOp(() =>
-      this.writeAndAck(MSG_WRITE_MOTION_ENABLE, new Uint8Array([enabled ? 1 : 0]), 2000),
+    return this.runOp(
+      () => this.writeAndAck(MSG_WRITE_MOTION_ENABLE, new Uint8Array([enabled ? 1 : 0]), 2000),
+      'setMotionEnabled',
     );
   }
 
@@ -556,7 +627,7 @@ class DeviceSession {
         if (!ok) return false;
       }
       return true;
-    });
+    }, 'manualMove');
   }
 
   homeAxis(): void {
@@ -580,23 +651,46 @@ class DeviceSession {
    */
   private async uploadProgram(ops: ProgramOp[]): Promise<void> {
     let pending: Uint8Array[] = [];
+    // Counted rather than logged per batch: a long program is hundreds of
+    // writes, and the useful facts are the totals plus where it stopped.
+    let batches = 0;
+    let waveforms = 0;
+    let bytes = 0;
     const flushMoves = async () => {
       for (const batch of batchMoveBuffers(pending, BATCH_MOVE_COUNT)) {
         if (this.aborting) throw new Error(ABORT_ERROR_MESSAGE);
+        batches += 1;
+        bytes += batch.length;
         await this.uploadWithRetry(MSG_WRITE_TEST_MOVE, batch, UPLOAD_DEFAULT_MAX_RETRIES);
       }
       pending = [];
     };
-    for (const op of ops) {
-      if (op.kind === 'move') {
-        pending.push(op.buf);
-      } else {
-        await flushMoves(); // preserve program order before the waveform
-        if (this.aborting) throw new Error(ABORT_ERROR_MESSAGE);
-        await this.uploadWithRetry(MSG_WRITE_TEST_WAVEFORM, op.buf, UPLOAD_DEFAULT_MAX_RETRIES);
+    try {
+      for (const op of ops) {
+        if (op.kind === 'move') {
+          pending.push(op.buf);
+        } else {
+          await flushMoves(); // preserve program order before the waveform
+          if (this.aborting) throw new Error(ABORT_ERROR_MESSAGE);
+          waveforms += 1;
+          bytes += op.buf.length;
+          await this.uploadWithRetry(MSG_WRITE_TEST_WAVEFORM, op.buf, UPLOAD_DEFAULT_MAX_RETRIES);
+        }
       }
+      await flushMoves();
+      logProto.debug('upload-done', undefined, { ...this.opTag(), batches, waveforms, bytes });
+    } catch (err) {
+      // How far the upload got before failing decides whether the SD file holds
+      // a partial program — the difference between a safe retry and a bad run.
+      logProto.error('upload-aborted', err instanceof Error ? err.message : String(err), {
+        ...this.opTag(),
+        batchesSent: batches,
+        waveformsSent: waveforms,
+        bytesSent: bytes,
+        totalOps: ops.length,
+      });
+      throw err;
     }
-    await flushMoves();
   }
 
   async runTest(params: RunTestParams): Promise<RunTestResult> {
@@ -615,7 +709,20 @@ class DeviceSession {
           return t !== '' && !t.startsWith(';');
         });
         const gaugeMm = resolveGaugeLengthMm(gaugeLengthMm, this.lastSample);
+        // What was actually uploaded, in a form that survives in a bug report:
+        // "the machine did the wrong moves" is answerable from this alone.
+        logProto.info('test-program', gcodeId, {
+          ...this.opTag(),
+          ...summariseGcode(lines),
+          gaugeMm,
+          gaugeSource: gaugeLengthMm === undefined ? 'sample' : 'caller',
+        });
+        const uploadStart = nowMs();
         await this.uploadProgram(gcodeLinesToProgram(lines, gaugeMm));
+        logProto.info('test-uploaded', gcodeId, {
+          ...this.opTag(),
+          durMs: Math.round(nowMs() - uploadStart),
+        });
         if (this.aborting) throw new Error(ABORT_ERROR_MESSAGE);
 
         // 3. Start the test only after the COMPLETE program (incl. trailing G122)
@@ -623,12 +730,23 @@ class DeviceSession {
         const runBuf = encodeTestRun({ gcodeId: gcodeId.slice(0, 6), testDataId: testDataId.slice(0, 6) });
         await this.writeAndAckOrThrow(MSG_WRITE_TEST_RUN, runBuf, 5000);
 
+        logProto.info('test-started', gcodeId, { ...this.opTag(), testDataId });
         return { success: true, gcodeId, testDataId };
       } catch (err) {
         // Invalidate any partially-written SD file: re-opening for WRITE truncates
         // it (firmware "wb"), so a half-uploaded program can never later run to EOF
         // and report a false "complete". Best-effort.
-        if (shouldInvalidatePartialUpload(false)) {
+        const aborted = this.aborting;
+        const invalidated = shouldInvalidatePartialUpload(false);
+        logProto.error('test-failed', err instanceof Error ? err.message : String(err), {
+          ...this.opTag(),
+          gcodeId,
+          aborted,
+          // Whether the partial SD file was truncated decides if a retry is
+          // safe or will run a half-written program.
+          invalidatedPartialUpload: invalidated,
+        });
+        if (invalidated) {
           try {
             this.client?.write(MSG_WRITE_TEST_MOVE, openId);
           } catch {
@@ -642,7 +760,7 @@ class DeviceSession {
           error: err instanceof Error ? err.message : String(err),
         };
       }
-    });
+    }, 'runTest');
   }
 
   async streamGcode(gcode: string): Promise<{ success: boolean; error?: string }> {
@@ -654,12 +772,21 @@ class DeviceSession {
       this.aborting = false;
       try {
         const gaugeMm = resolveGaugeLengthMm(undefined, this.lastSample);
+        logProto.info('stream-program', undefined, {
+          ...this.opTag(),
+          ...summariseGcode(lines),
+          gaugeMm,
+        });
         await this.uploadProgram(gcodeLinesToProgram(lines, gaugeMm));
         return { success: true };
       } catch (err) {
+        logProto.error('stream-failed', err instanceof Error ? err.message : String(err), {
+          ...this.opTag(),
+          aborted: this.aborting,
+        });
         return { success: false, error: err instanceof Error ? err.message : String(err) };
       }
-    });
+    }, 'streamGcode');
   }
 
   // ── Download test data from the SD card → CSV ──
@@ -672,11 +799,15 @@ class DeviceSession {
 
     return this.runOp(async () => {
     this.aborting = false;
+    const downloadStart = nowMs();
+    let requests = 0;
+    let nackRetries = 0;
     try {
       const chunks: Uint8Array[] = [];
       let sampleIndex = 0;
       let downloadedBytes = 0;
       let done = false;
+      logProto.info('download-start', testName, { ...this.opTag() });
 
       while (!done) {
         if (this.aborting) throw new Error(ABORT_ERROR_MESSAGE);
@@ -691,6 +822,7 @@ class DeviceSession {
 
         while (chunk === null) {
            
+          requests += 1;
           const next = await this.requestDownloadChunk(request, 10000);
           if (next.kind === 'nack') {
             // Retry a transient "not ready" / SD-BUSY NACK at ANY point, not only
@@ -699,6 +831,7 @@ class DeviceSession {
             // downloaded. The first chunk waits longer (file may not exist yet).
             if (shouldRetryDownloadNack(notReadyRetries, sampleIndex)) {
               notReadyRetries += 1;
+              nackRetries += 1;
                
               await delay(DOWNLOAD_RETRY_DELAY_MS);
               continue;
@@ -743,16 +876,77 @@ class DeviceSession {
         totalBytes: binary.length,
         status: 'complete',
       });
+      logProto.info('download-done', testName, {
+        ...this.opTag(),
+        bytes: binary.length,
+        csvChars: csv.length,
+        requests,
+        // Retries are the early warning for a flaky SD path: a download that
+        // succeeded after 40 BUSY NACKs is a bug report waiting to happen.
+        nackRetries,
+        durMs: Math.round(nowMs() - downloadStart),
+      });
       return { success: true, csv, sampleBytes: binary.length };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
+      logProto.error('download-failed', message, {
+        ...this.opTag(),
+        testName,
+        requests,
+        nackRetries,
+        aborted: this.aborting,
+        durMs: Math.round(nowMs() - downloadStart),
+      });
       onProgress?.({ fileName: testName, bytesDownloaded: 0, totalBytes: 0, status: 'error', error: message });
       return { success: false, error: message };
     }
-    });
+    }, 'downloadTestFile');
   }
 
   // ── Internals ──
+
+  /**
+   * Warn when bytes keep arriving but nothing decodes.
+   *
+   * The protocol core silently discards data that is not a valid frame, so a
+   * wrong baud rate, a noisy cable or a half-flashed board produces a stream of
+   * received bytes and *no* log entry whatsoever — the app just looks dead.
+   * That is the single most common "it doesn't work" report, and without this
+   * it is invisible in a bundle.
+   *
+   * Rate-limited to two warnings: enough to prove the condition and carry the
+   * bytes, without flooding a ring that a maintainer still needs to read.
+   */
+  private checkUndecodableTraffic(): void {
+    const GIBBERISH_WINDOW_MS = 2000;
+    const GIBBERISH_MIN_BYTES = 64;
+    const GIBBERISH_MAX_WARNINGS = 2;
+
+    const now = nowMs();
+    if (this.gibberishAt === 0) {
+      this.gibberishAt = now;
+      this.gibberishBytes = this.stats.bytesIn;
+      this.gibberishEvents = this.stats.decoded;
+      return;
+    }
+    if (now - this.gibberishAt < GIBBERISH_WINDOW_MS) return;
+
+    const bytes = this.stats.bytesIn - this.gibberishBytes;
+    const decoded = this.stats.decoded - this.gibberishEvents;
+    this.gibberishAt = now;
+    this.gibberishBytes = this.stats.bytesIn;
+    this.gibberishEvents = this.stats.decoded;
+
+    if (bytes < GIBBERISH_MIN_BYTES || decoded > 0) return;
+    if (this.gibberishWarnings >= GIBBERISH_MAX_WARNINGS) return;
+    this.gibberishWarnings += 1;
+    logProto.error('undecodable', 'receiving bytes that do not decode as frames', {
+      bytes,
+      windowMs: GIBBERISH_WINDOW_MS,
+      // Usually a baud mismatch or a board that is not running MaD firmware.
+      tail: byteRing.tailHex(64),
+    });
+  }
 
   private tick(): void {
     if (!this.client) return;
@@ -767,6 +961,9 @@ class DeviceSession {
       logger('wasm').error('poll-trap', String(err), {
         ...this.stats,
         ...byteRing.stats(),
+        ...this.opTag(),
+        // A trap in the protocol core is almost always the bytes that fed it.
+        tail: byteRing.tailHex(96),
       });
       this.emit([{ kind: 'error', message: `poll: ${String(err)}` }]);
       void this.shutdown(`protocol error: ${String(err)}`);
@@ -807,8 +1004,13 @@ class DeviceSession {
         this.stats.lastErrorAt = Date.now();
       } else if (e.kind === 'timeout') {
         this.stats.timeouts += 1;
-      } else if (e.kind === 'ack' && !e.success) {
-        this.stats.nacks += 1;
+      } else {
+        // Anything that is not an error or a timeout came off the wire as a
+        // valid frame. Counted separately from `events` because the
+        // undecodable-traffic watchdog must not be placated by the very
+        // timeouts that a garbled link produces.
+        this.stats.decoded += 1;
+        if (e.kind === 'ack' && !e.success) this.stats.nacks += 1;
       }
     }
 
@@ -822,6 +1024,7 @@ class DeviceSession {
     this.periodic.maybeFlush(this.stats.bytesIn, this.stats.bytesOut);
 
     if (events.length > 0) this.emit(events);
+    this.checkUndecodableTraffic();
   }
 
   /**
@@ -845,27 +1048,38 @@ class DeviceSession {
 
     switch (ev.event) {
       case 'ack':
-        logProto.info('ack', commandName(command));
+        logProto.info('ack', commandName(command, 'write'), this.opTag(command));
         break;
       case 'nack':
-        logProto.warn('nack', commandName(command), { command });
+        logProto.warn('nack', commandName(command, 'write'), { command, ...this.opTag(command) });
         break;
       case 'timeout':
         logProto.warn('timeout', 'no response', {
-          command: ev.frame && ev.frame.length > 2 ? commandName(ev.frame[2]) : 'unknown',
+          command:
+            ev.frame && ev.frame.length > 2
+              ? commandName(ev.frame[2], this.dirFor(ev.frame[2]))
+              : 'unknown',
           frameBytes: ev.frame?.length ?? 0,
+          ...this.opTag(),
         });
         break;
       case 'error':
         logProto.error('error', ev.message ?? 'unknown error', {
-          command: command >= 0 ? commandName(command) : undefined,
+          command: command >= 0 ? commandName(command, this.dirFor(command)) : undefined,
+          ...this.opTag(),
+          // The bytes that caused the rejection are the whole story for a
+          // framing/CRC fault, and they are gone from the ring by export time.
+          tail: byteRing.tailHex(64),
         });
         break;
       case 'notification':
         logProto.info('notification', undefined, { bytes: u8(ev.payload).length });
         break;
       case 'data':
-        logProto.info('rx', commandName(command), { bytes: u8(ev.payload).length });
+        logProto.info('rx', commandName(command, this.dirFor(command)), {
+          bytes: u8(ev.payload).length,
+          ...this.opTag(command),
+        });
         break;
       default:
         break;
@@ -913,13 +1127,103 @@ class DeviceSession {
   }
 
   /** Serialize an on-demand operation so only one request/response is in flight. */
-  private runOp<T>(fn: () => Promise<T>): Promise<T> {
-    const next = this.opChain.then(fn, fn);
+  private runOp<T>(fn: () => Promise<T>, name?: string): Promise<T> {
+    const wrapped = name === undefined ? fn : this.instrumentOp(fn, name);
+    const next = this.opChain.then(wrapped, wrapped);
     this.opChain = next.then(
       () => undefined,
       () => undefined,
     );
     return next;
+  }
+
+  /**
+   * Wrap a serialized operation so every frame it produces can be traced back
+   * to the user action that caused it.
+   *
+   * `runOp` guarantees a single in-flight operation, so a plain field is a
+   * correct "current op" marker — no async-context plumbing needed. Frames that
+   * arrive while an op is active get its id, which turns a flat frame log into
+   * "jog #7 → tx WRITE_MANUAL_MOVE → nack" instead of leaving the reader to
+   * guess which write a NACK belongs to.
+   *
+   * Poll-driven traffic unrelated to the op can interleave, so `logRawEvent`
+   * only tags frames whose command matches the op's own writes.
+   */
+  private instrumentOp<T>(fn: () => Promise<T>, name: string): () => Promise<T> {
+    return async () => {
+      const id = (this.opSeq += 1);
+      const previous = this.activeOp;
+      const startedAt = nowMs();
+      this.activeOp = { id, name, command: null, dir: null };
+      logProto.info('op-start', name, { op: id });
+      try {
+        const result = await fn();
+        logProto.info('op-end', name, {
+          op: id,
+          ok: true,
+          durMs: Math.round(nowMs() - startedAt),
+        });
+        return result;
+      } catch (err) {
+        // Ops that resolve with `{ success: false }` are logged by their own
+        // call sites; this path is a genuine throw.
+        logProto.error('op-end', name, {
+          op: id,
+          ok: false,
+          durMs: Math.round(nowMs() - startedAt),
+          reason: err instanceof Error ? err.message : String(err),
+        });
+        throw err;
+      } finally {
+        this.activeOp = previous;
+      }
+    };
+  }
+
+  /**
+   * Record which command the in-flight op is writing, so an inbound ack/nack
+   * for an unrelated command (a late reply, a firmware-initiated frame) does
+   * not get mis-attributed to it.
+   */
+  private claimOpCommand(command: number, dir: CommandDir): void {
+    if (this.activeOp === null) return;
+    this.activeOp.command = command;
+    this.activeOp.dir = dir;
+  }
+
+  /**
+   * Issue a request-style read, logged.
+   *
+   * Reads go out via `client.read()` rather than `writeAndAck`, so before this
+   * they produced no `tx` entry at all — a report showed the response (or the
+   * timeout) with nothing explaining what had been asked for.
+   */
+  private requestRead(command: number): void {
+    this.claimOpCommand(command, 'read');
+    logProto.info('tx', commandName(command, 'read'), { kind: 'read', ...this.opTag() });
+    this.client?.read(command, true, undefined);
+  }
+
+  /**
+   * Best-known direction for an inbound frame's command id.
+   *
+   * Nothing on the wire says which side an id belongs to, so fall back to the
+   * in-flight operation when it matches; otherwise leave it undefined and let
+   * `commandName` render the ambiguity rather than guess.
+   */
+  private dirFor(command: number): CommandDir | undefined {
+    const active = this.activeOp;
+    if (active !== null && active.command === command && active.dir !== null) return active.dir;
+    return undefined;
+  }
+
+  /** `{ op: id }` when an operation is in flight, else empty — spread into log data. */
+  private opTag(command?: number): { op?: number } {
+    const active = this.activeOp;
+    if (active === null) return {};
+    if (command !== undefined && active.command !== null && active.command !== command) return {};
+    return { op: active.id };
   }
 
   private waitFor(
@@ -964,19 +1268,23 @@ class DeviceSession {
   private async writeAndAck(command: number, data: Uint8Array, timeoutMs: number): Promise<boolean> {
     const p = this.waitFor((e) => e.kind === 'ack' && e.command === command, timeoutMs, `ack(${command})`, command);
     const started = nowMs();
-    logProto.info('tx', commandName(command), { bytes: data.length, timeoutMs });
+    this.claimOpCommand(command, 'write');
+    logProto.info('tx', commandName(command, 'write'), { bytes: data.length, timeoutMs, ...this.opTag() });
     this.client?.write(command, data);
     try {
       const e = (await p) as Extract<DeviceEvent, { kind: 'ack' }>;
       // Round-trip time is the cheapest early warning there is: a link that is
       // about to fail usually gets slow before it stops answering.
-      logProto.debug('rtt', commandName(command), {
+      logProto.debug('rtt', commandName(command, 'write'), {
+      ...this.opTag(),
+        ...this.opTag(),
         durMs: Math.round(nowMs() - started),
         success: e.success,
       });
       return e.success;
     } catch (err) {
-      logProto.warn('tx-failed', commandName(command), {
+      logProto.warn('tx-failed', commandName(command, 'write'), {
+        ...this.opTag(),
         durMs: Math.round(nowMs() - started),
         reason: err instanceof Error ? err.message : String(err),
       });
@@ -987,10 +1295,12 @@ class DeviceSession {
   private async writeAndAckOrThrow(command: number, data: Uint8Array, timeoutMs: number): Promise<void> {
     const p = this.waitFor((e) => e.kind === 'ack' && e.command === command, timeoutMs, `ack(${command})`, command);
     const started = nowMs();
-    logProto.info('tx', commandName(command), { bytes: data.length, timeoutMs });
+    this.claimOpCommand(command, 'write');
+    logProto.info('tx', commandName(command, 'write'), { bytes: data.length, timeoutMs, ...this.opTag() });
     this.client?.write(command, data);
     const e = (await p) as Extract<DeviceEvent, { kind: 'ack' }>;
-    logProto.debug('rtt', commandName(command), {
+    logProto.debug('rtt', commandName(command, 'write'), {
+      ...this.opTag(),
       durMs: Math.round(nowMs() - started),
       success: e.success,
     });
@@ -1009,10 +1319,10 @@ class DeviceSession {
         attempt += 1;
         const reason = err instanceof Error ? err.message : String(err);
         if (!shouldRetryUpload(attempt, maxRetries)) {
-          logProto.error('upload-failed', commandName(command), { attempt, reason });
+          logProto.error('upload-failed', commandName(command, 'write'), { attempt, reason, ...this.opTag() });
           throw err;
         }
-        logProto.warn('upload-retry', commandName(command), { attempt, maxRetries, reason });
+        logProto.warn('upload-retry', commandName(command, 'write'), { attempt, maxRetries, reason, ...this.opTag() });
 
         await delay(1000);
       }

--- a/Software/Control/src/device/commandNames.test.ts
+++ b/Software/Control/src/device/commandNames.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { commandName, isPeriodicCommand, summariseGcode } from './commandNames';
+import {
+  MSG_READ_SAMPLE,
+  MSG_READ_STATE,
+  MSG_WRITE_TEST_RUN,
+  MSG_READ_MACHINE_CONFIGURATION,
+  MSG_WRITE_MOTION_ENABLE,
+} from '@/protocol/generated/protoemb';
+
+describe('commandName', () => {
+  it('names a known command and keeps the id visible', () => {
+    expect(commandName(MSG_WRITE_TEST_RUN, 'write')).toBe(`WRITE_TEST_RUN(${MSG_WRITE_TEST_RUN})`);
+  });
+
+  it('degrades to a readable placeholder for an unmapped id', () => {
+    expect(commandName(9999, 'write')).toBe('cmd(9999)');
+  });
+
+  it('resolves ids that exist on BOTH sides by direction', () => {
+    // Reads and writes share the id space, so a single map would mislabel half
+    // the traffic — command 2 is READ_MACHINE_CONFIGURATION *and* WRITE_TEST_RUN.
+    expect(MSG_READ_MACHINE_CONFIGURATION).toBe(MSG_WRITE_TEST_RUN);
+    expect(commandName(MSG_READ_MACHINE_CONFIGURATION, 'read')).toBe('READ_MACHINE_CONFIGURATION(2)');
+    expect(commandName(MSG_WRITE_TEST_RUN, 'write')).toBe('WRITE_TEST_RUN(2)');
+  });
+
+  it('shows the ambiguity rather than guessing when direction is unknown', () => {
+    // A confidently wrong name is worse in a bug report than a hedged one.
+    expect(commandName(MSG_READ_STATE)).toBe('READ_STATE|WRITE_MOTION_ENABLE(1)');
+    expect(MSG_READ_STATE).toBe(MSG_WRITE_MOTION_ENABLE);
+  });
+
+  it('does not hedge an id that exists on only one side', () => {
+    expect(commandName(8)).toBe('WRITE_TEST_WAVEFORM(8)');
+  });
+
+  it('never returns a read name for a write direction', () => {
+    expect(commandName(MSG_READ_SAMPLE, 'write')).toBe('WRITE_MACHINE_CONFIGURATION(0)');
+    expect(commandName(MSG_READ_SAMPLE, 'read')).toBe('READ_SAMPLE(0)');
+  });
+});
+
+describe('isPeriodicCommand', () => {
+  it('covers exactly the two high-rate reads', () => {
+    expect(isPeriodicCommand(MSG_READ_SAMPLE)).toBe(true);
+    expect(isPeriodicCommand(MSG_READ_STATE)).toBe(true);
+    expect(isPeriodicCommand(MSG_WRITE_TEST_RUN)).toBe(false);
+  });
+});
+
+describe('summariseGcode', () => {
+  it('counts lines, bytes and opcodes', () => {
+    const s = summariseGcode(['G90', 'G1 X10 F100', 'G1 X0 F100', 'G122']);
+    expect(s.lines).toBe(4);
+    expect(s.opcodes).toEqual({ G90: 1, G1: 2, G122: 1 });
+    expect(s.endsWithG122).toBe(true);
+  });
+
+  it('flags a program missing its terminating G122', () => {
+    // The firmware contract requires G122 to signal completion; a program
+    // without it hangs the run, so this is the check worth having.
+    expect(summariseGcode(['G90', 'G1 X10 F100']).endsWithG122).toBe(false);
+  });
+
+  it('hashes content, not identity', () => {
+    const a = summariseGcode(['G1 X10 F100']);
+    const b = summariseGcode(['G1 X10 F100']);
+    const c = summariseGcode(['G1 X11 F100']);
+    expect(a.hash).toBe(b.hash);
+    expect(a.hash).not.toBe(c.hash);
+    expect(a.hash).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it('is case-insensitive about opcodes and tolerates leading whitespace', () => {
+    expect(summariseGcode(['  g1 X1', 'M5']).opcodes).toEqual({ G1: 1, M5: 1 });
+  });
+
+  it('handles an empty program without throwing', () => {
+    const s = summariseGcode([]);
+    expect(s.lines).toBe(0);
+    expect(s.opcodes).toEqual({});
+    expect(s.endsWithG122).toBe(false);
+  });
+
+  it('ignores lines that carry no opcode', () => {
+    expect(summariseGcode(['X10 Y20', 'G1 X1']).opcodes).toEqual({ G1: 1 });
+  });
+});

--- a/Software/Control/src/device/commandNames.ts
+++ b/Software/Control/src/device/commandNames.ts
@@ -28,12 +28,21 @@ import {
   MSG_WRITE_FILE_DOWNLOAD,
 } from '@/protocol/generated/protoemb';
 
-const NAMES = new Map<number, string>([
+/**
+ * Reads and writes share the id space — `READ_MACHINE_CONFIGURATION` and
+ * `WRITE_TEST_RUN` are both command 2 — so a single id→name map silently
+ * mislabels half the traffic. Keep them apart and resolve with the direction
+ * the call site knows.
+ */
+const READ_NAMES = new Map<number, string>([
   [MSG_READ_SAMPLE, 'READ_SAMPLE'],
   [MSG_READ_STATE, 'READ_STATE'],
   [MSG_READ_MACHINE_CONFIGURATION, 'READ_MACHINE_CONFIGURATION'],
   [MSG_READ_FIRMWARE_VERSION, 'READ_FIRMWARE_VERSION'],
   [MSG_READ_SAMPLE_PROFILE, 'READ_SAMPLE_PROFILE'],
+]);
+
+const WRITE_NAMES = new Map<number, string>([
   [MSG_WRITE_MACHINE_CONFIGURATION_WRITE, 'WRITE_MACHINE_CONFIGURATION'],
   [MSG_WRITE_MOTION_ENABLE, 'WRITE_MOTION_ENABLE'],
   [MSG_WRITE_TEST_RUN, 'WRITE_TEST_RUN'],
@@ -46,10 +55,24 @@ const NAMES = new Map<number, string>([
   [MSG_WRITE_FILE_DOWNLOAD, 'WRITE_FILE_DOWNLOAD'],
 ]);
 
-/** `'WRITE_MOTION_ENABLE(21)'`, or `'cmd(99)'` for anything unmapped. */
-export function commandName(command: number): string {
-  const name = NAMES.get(command);
-  return name ? `${name}(${command})` : `cmd(${command})`;
+/** Which side of the protocol a command id should be read against. */
+export type CommandDir = 'read' | 'write';
+
+/**
+ * `'WRITE_MOTION_ENABLE(1)'` when the direction is known.
+ *
+ * Without one, an id that exists on both sides renders as
+ * `'READ_STATE|WRITE_MOTION_ENABLE(1)'` — honest ambiguity, because a
+ * confidently wrong name is worse in a bug report than a hedged one.
+ */
+export function commandName(command: number, dir?: CommandDir): string {
+  const read = READ_NAMES.get(command);
+  const write = WRITE_NAMES.get(command);
+  if (dir === 'read') return read ? `${read}(${command})` : `cmd(${command})`;
+  if (dir === 'write') return write ? `${write}(${command})` : `cmd(${command})`;
+  if (read && write) return `${read}|${write}(${command})`;
+  const only = read ?? write;
+  return only ? `${only}(${command})` : `cmd(${command})`;
 }
 
 /**
@@ -58,4 +81,37 @@ export function commandName(command: number): string {
  */
 export function isPeriodicCommand(command: number): boolean {
   return command === MSG_READ_SAMPLE || command === MSG_READ_STATE;
+}
+
+/**
+ * Summarise a G-code program for the log.
+ *
+ * The full program can be thousands of lines, so this keeps what actually
+ * answers "did we upload the right thing": size, a content hash (two runs of
+ * the same profile must produce the same digest — if they don't, the transform
+ * is non-deterministic), and a per-opcode histogram. The histogram makes the
+ * project's classic footgun visible at a glance: a program missing its trailing
+ * `G122` never signals completion to the firmware.
+ */
+export function summariseGcode(lines: readonly string[]): Record<string, unknown> {
+  const opcodes: Record<string, number> = {};
+  let bytes = 0;
+  // FNV-1a: tiny, dependency-free, and only needs to detect difference.
+  let hash = 0x811c9dc5;
+  for (const line of lines) {
+    bytes += line.length + 1;
+    for (let i = 0; i < line.length; i++) {
+      hash ^= line.charCodeAt(i);
+      hash = Math.imul(hash, 0x01000193);
+    }
+    const op = /^\s*([GM]\d+)/i.exec(line)?.[1]?.toUpperCase();
+    if (op !== undefined) opcodes[op] = (opcodes[op] ?? 0) + 1;
+  }
+  return {
+    lines: lines.length,
+    bytes,
+    hash: (hash >>> 0).toString(16).padStart(8, '0'),
+    opcodes,
+    endsWithG122: /^\s*G122\b/i.test(lines[lines.length - 1] ?? ''),
+  };
 }

--- a/Software/Control/src/diagnostics/boot.ts
+++ b/Software/Control/src/diagnostics/boot.ts
@@ -8,7 +8,8 @@
  * ~100 Hz stream and reads exactly like a protocol fault if you can't see it).
  */
 
-import { logger, type LogLevel } from './log';
+import { logger, nowMs, type LogLevel } from './log';
+import { startLogPersistence, type LogPersistence } from './persist';
 
 const log = logger('app');
 
@@ -17,6 +18,20 @@ declare const __APP_VERSION__: string;
 declare const __GIT_SHA__: string;
 
 let installed = false;
+
+/**
+ * Identifies this page load, so a persisted log can be told apart from the one
+ * that a reload destroyed. Derived from the boot time plus a random suffix —
+ * `crypto.randomUUID` is not available on every target this app runs on.
+ */
+export const SESSION_ID = `s-${Date.now().toString(36)}-${Math.floor(Math.random() * 1e6).toString(36)}`;
+
+let persistence: LogPersistence | null = null;
+
+/** The live persistence handle, for the export path to flush before bundling. */
+export function logPersistence(): LogPersistence | null {
+  return persistence;
+}
 
 /** One line that identifies the environment a report came from. */
 function logBootEnvironment(): void {
@@ -28,6 +43,7 @@ function logBootEnvironment(): void {
     version: typeof __APP_VERSION__ === 'string' ? __APP_VERSION__ : 'unknown',
     gitSha: typeof __GIT_SHA__ === 'string' ? __GIT_SHA__ : 'unknown',
     mode: import.meta.env.MODE,
+    sessionId: SESSION_ID,
     userAgent: navigator.userAgent,
     language: navigator.language,
     hardwareConcurrency: nav.hardwareConcurrency ?? null,
@@ -82,6 +98,84 @@ function trackEnvironmentChanges(): void {
   window.addEventListener('offline', () => log.warn('offline'));
 }
 
+/** A main-thread stall longer than this is user-visible jank worth recording. */
+const LONG_TASK_MS = 200;
+/** How often to check heap growth. Slow: this is for leaks, not spikes. */
+const HEAP_SAMPLE_MS = 30_000;
+/** Report heap only when it moved by more than this since the last report. */
+const HEAP_DELTA_MB = 25;
+
+/**
+ * Watch for main-thread stalls.
+ *
+ * The device worker keeps the ~100 Hz stream alive independently, so a frozen
+ * UI and a broken device link are different faults with identical symptoms
+ * ("it stopped updating"). Recording stalls is what separates them.
+ *
+ * `longtask` entries are the accurate source; the interval fallback covers
+ * browsers where that entry type is unavailable, and also catches stalls that
+ * block the observer's own delivery.
+ */
+function trackMainThreadHealth(): void {
+  try {
+    if (
+      typeof PerformanceObserver !== 'undefined' &&
+      PerformanceObserver.supportedEntryTypes?.includes('longtask')
+    ) {
+      const observer = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          if (entry.duration >= LONG_TASK_MS) {
+            log.warn('jank', 'main thread blocked', {
+              durMs: Math.round(entry.duration),
+              source: entry.name,
+            });
+          }
+        }
+      });
+      observer.observe({ entryTypes: ['longtask'] });
+    }
+  } catch {
+    // Entry type unsupported — the interval below still covers the worst cases.
+  }
+
+  // A timer that should fire every second but fires late by N ms means the main
+  // thread was busy for N ms. Deliberately ignores hidden tabs, where the
+  // browser throttles timers on purpose and a "stall" would be a false alarm.
+  const TICK_MS = 1000;
+  let expected = nowMs() + TICK_MS;
+  setInterval(() => {
+    const now = nowMs();
+    const late = now - expected;
+    expected = now + TICK_MS;
+    if (late >= LONG_TASK_MS && !document.hidden) {
+      log.warn('stall', 'timer ran late', { lateMs: Math.round(late) });
+    }
+  }, TICK_MS);
+}
+
+/**
+ * Sample heap usage, reporting only meaningful movement.
+ *
+ * A session that climbs steadily over an hour is a leak; one that sits flat is
+ * not. Chromium-only (`performance.memory`), which is the app's only target.
+ */
+function trackHeap(): void {
+  const perf = performance as Performance & {
+    memory?: { usedJSHeapSize: number; jsHeapSizeLimit: number };
+  };
+  if (perf.memory === undefined) return;
+  const mb = (bytes: number): number => Math.round(bytes / (1024 * 1024));
+  let lastReported = mb(perf.memory.usedJSHeapSize);
+  log.info('heap', 'baseline', { usedMb: lastReported, limitMb: mb(perf.memory.jsHeapSizeLimit) });
+  setInterval(() => {
+    const used = mb(perf.memory?.usedJSHeapSize ?? 0);
+    if (Math.abs(used - lastReported) < HEAP_DELTA_MB) return;
+    const grew = used > lastReported;
+    log.info('heap', grew ? 'grew' : 'released', { usedMb: used, deltaMb: used - lastReported });
+    lastReported = used;
+  }, HEAP_SAMPLE_MS);
+}
+
 /**
  * Install app-level capture. Idempotent — React StrictMode double-invokes
  * effects in dev, and double-wrapping the console would double every line.
@@ -92,4 +186,7 @@ export function installAppDiagnostics(): void {
   interceptConsole();
   logBootEnvironment();
   trackEnvironmentChanges();
+  trackMainThreadHealth();
+  trackHeap();
+  persistence = startLogPersistence(SESSION_ID);
 }

--- a/Software/Control/src/diagnostics/byteRing.test.ts
+++ b/Software/Control/src/diagnostics/byteRing.test.ts
@@ -208,3 +208,47 @@ describe('ByteRing — reset', () => {
     expect(residentBytes(ring)).toEqual(Uint8Array.of(9, 9, 9));
   });
 });
+
+describe('ByteRing.tailHex', () => {
+  it('returns the most recent bytes, oldest → newest', () => {
+    const ring = new ByteRing(64, 8);
+    ring.push('rx', Uint8Array.from([0x01, 0x02, 0x03, 0xff]));
+    expect(ring.tailHex(4)).toBe('01 02 03 ff');
+  });
+
+  it('caps at the requested count', () => {
+    const ring = new ByteRing(64, 8);
+    ring.push('rx', Uint8Array.from([1, 2, 3, 4, 5, 6]));
+    expect(ring.tailHex(2)).toBe('05 06');
+  });
+
+  it('never returns more than has been written', () => {
+    const ring = new ByteRing(64, 8);
+    ring.push('rx', Uint8Array.from([0xaa]));
+    expect(ring.tailHex(32)).toBe('aa');
+  });
+
+  it('is empty before anything is pushed', () => {
+    expect(new ByteRing(64, 8).tailHex()).toBe('');
+  });
+
+  it('reads across a wrap correctly', () => {
+    // Capacity 4: the last four bytes span the seam in the backing buffer.
+    const ring = new ByteRing(4, 8);
+    ring.push('rx', Uint8Array.from([1, 2, 3]));
+    ring.push('tx', Uint8Array.from([4, 5]));
+    expect(ring.tailHex(4)).toBe('02 03 04 05');
+  });
+
+  it('cannot return more than the ring holds', () => {
+    const ring = new ByteRing(4, 8);
+    ring.push('rx', Uint8Array.from([1, 2, 3, 4, 5, 6]));
+    expect(ring.tailHex(64)).toBe('03 04 05 06');
+  });
+
+  it('zero-pads single-digit bytes so offsets stay readable', () => {
+    const ring = new ByteRing(16, 4);
+    ring.push('rx', Uint8Array.from([0x00, 0x0f, 0x10]));
+    expect(ring.tailHex(3)).toBe('00 0f 10');
+  });
+});

--- a/Software/Control/src/diagnostics/byteRing.ts
+++ b/Software/Control/src/diagnostics/byteRing.ts
@@ -197,6 +197,26 @@ export class ByteRing {
     return out;
   }
 
+  /**
+   * Hex of the most recent `n` resident bytes, oldest → newest.
+   *
+   * For attaching to a decode failure: when the protocol core rejects a frame,
+   * the bytes that caused it are the whole story, and by export time they may
+   * be long gone. Small and bounded, so it is safe to inline in a log entry —
+   * unlike `snapshot()`, which materialises the entire window.
+   */
+  tailHex(n = 64): string {
+    const len = Math.min(n, this.written, this.capacity);
+    if (len <= 0) return '';
+    const bytes = this.read(this.written - len, len);
+    let out = '';
+    for (let i = 0; i < len; i++) {
+      out += bytes[i].toString(16).padStart(2, '0');
+      if (i + 1 < len) out += ' ';
+    }
+    return out;
+  }
+
   /** Cheap counters for the bundle header — no allocation of payload data. */
   stats(): {
     chunksPushed: number;

--- a/Software/Control/src/diagnostics/exportBundle.ts
+++ b/Software/Control/src/diagnostics/exportBundle.ts
@@ -8,6 +8,9 @@
  */
 
 import { logSnapshot, type LogSnapshot } from './log';
+import { summariseForTriage, type TriageSummary } from './triage';
+import { logPersistence, SESSION_ID } from './boot';
+import { readPreviousSession, type PersistedSession } from './persist';
 import { deviceClient } from '@/device/session';
 import { useStore } from '@/store/useStore';
 import type { ByteRingSnapshot } from './byteRing';
@@ -16,6 +19,9 @@ declare const __APP_VERSION__: string;
 declare const __GIT_SHA__: string;
 
 export interface DiagnosticsBundle {
+  /** Read this first — everything below is the evidence behind it. */
+  triage: TriageSummary;
+  sessionId: string;
   generatedAt: string;
   version: string;
   gitSha: string;
@@ -32,9 +38,23 @@ export interface DiagnosticsBundle {
   log: LogSnapshot;
   /** Raw serial tail — omitted unless explicitly requested (see options). */
   serialTail?: ByteRingSnapshot;
+  /**
+   * The previous page load's log, when one was persisted.
+   *
+   * Present after a reload, which is exactly the case the in-memory ring cannot
+   * cover: if the app froze and the user restarted it, the failure is in here
+   * and not in `log`. A `closed: false` on it means that session never shut
+   * down cleanly.
+   */
+  previousSession?: PersistedSession;
 }
 
 export interface BundleOptions {
+  /**
+   * Attach the previous session's persisted log. On by default: a report filed
+   * after a reload is otherwise missing the very failure that caused it.
+   */
+  includePreviousSession?: boolean;
   /**
    * Include the raw RX/TX byte window. Opt-in: it is the most useful artifact
    * for a framing or CRC bug and also the most opaque, so the choice to attach
@@ -47,6 +67,13 @@ export async function buildDiagnosticsBundle(
   opts: BundleOptions = {},
 ): Promise<DiagnosticsBundle> {
   const s = useStore.getState();
+  // Get everything buffered into IndexedDB before snapshotting, so a bundle and
+  // the persisted copy cannot disagree.
+  try {
+    await logPersistence()?.flush();
+  } catch {
+    // Persistence is best-effort and must never block a report.
+  }
   let worker: unknown = null;
   try {
     worker = await deviceClient.getDiagnostics();
@@ -65,7 +92,19 @@ export async function buildDiagnosticsBundle(
     }
   }
 
+  let previousSession: PersistedSession | undefined;
+  if (opts.includePreviousSession !== false) {
+    try {
+      previousSession = (await readPreviousSession(SESSION_ID)) ?? undefined;
+    } catch {
+      previousSession = undefined;
+    }
+  }
+
+  const log = logSnapshot();
   return {
+    triage: summariseForTriage(log),
+    sessionId: SESSION_ID,
     generatedAt: new Date().toISOString(),
     version: typeof __APP_VERSION__ === 'string' ? __APP_VERSION__ : 'unknown',
     gitSha: typeof __GIT_SHA__ === 'string' ? __GIT_SHA__ : 'unknown',
@@ -82,8 +121,9 @@ export async function buildDiagnosticsBundle(
       portLabel: s.portLabel,
     },
     worker,
-    log: logSnapshot(),
+    log,
     ...(serialTail ? { serialTail } : {}),
+    ...(previousSession ? { previousSession } : {}),
   };
 }
 

--- a/Software/Control/src/diagnostics/log.ts
+++ b/Software/Control/src/diagnostics/log.ts
@@ -24,7 +24,17 @@
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
-export type LogCat = 'app' | 'device' | 'proto' | 'store' | 'ui' | 'fs' | 'perf' | 'wasm';
+export type LogCat =
+  | 'app'
+  | 'device'
+  | 'proto'
+  | 'store'
+  | 'ui'
+  | 'fs'
+  | 'perf'
+  | 'wasm'
+  /** Firmware flashing over the P2 boot ROM — a different protocol to `proto`. */
+  | 'flash';
 
 export type LogThread = 'main' | 'worker';
 

--- a/Software/Control/src/diagnostics/persist.ts
+++ b/Software/Control/src/diagnostics/persist.ts
@@ -1,0 +1,189 @@
+/**
+ * Crash-survivable log persistence (main thread).
+ *
+ * The in-memory ring dies with the page, which is the wrong behaviour for the
+ * case people most often report: the app froze or crashed, so they reloaded —
+ * and reloading destroys the only evidence of what went wrong. This mirrors the
+ * merged timeline into IndexedDB as it is produced, so the *previous* session's
+ * log is still there after a restart and rides along in the next bug report.
+ *
+ * Design constraints:
+ *  - Never on the hot path. Entries are buffered and flushed on a timer, plus
+ *    on `visibilitychange`, which is the last reliable moment before a tab dies.
+ *  - Never able to break the app. Every IndexedDB call is best-effort; a denied
+ *    quota or a private-mode failure degrades to "no persistence", not an error.
+ *  - Bounded. One record per session, oldest sessions pruned, entries capped —
+ *    diagnostics must not grow without limit in someone's browser profile.
+ */
+
+import { logSnapshot, subscribeLog, type LogEntry } from './log';
+
+const DB_NAME = 'mad-diagnostics';
+const DB_VERSION = 1;
+const STORE = 'sessions';
+
+/** Sessions retained, newest first. Two prior sessions is plenty of history. */
+export const MAX_SESSIONS = 3;
+/** Entries persisted per session — the tail is what matters after a crash. */
+export const MAX_PERSISTED_ENTRIES = 2000;
+/** Flush cadence. Slow enough to be free, fast enough to survive a hard crash. */
+const FLUSH_INTERVAL_MS = 5000;
+
+export interface PersistedSession {
+  id: string;
+  startedAt: number;
+  updatedAt: number;
+  entries: LogEntry[];
+  /** True once the session ended cleanly, so a crash is distinguishable. */
+  closed: boolean;
+}
+
+function openDb(): Promise<IDBDatabase | null> {
+  return new Promise((resolve) => {
+    try {
+      const req = indexedDB.open(DB_NAME, DB_VERSION);
+      req.onupgradeneeded = () => {
+        const db = req.result;
+        if (!db.objectStoreNames.contains(STORE)) db.createObjectStore(STORE, { keyPath: 'id' });
+      };
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => resolve(null);
+      req.onblocked = () => resolve(null);
+    } catch {
+      resolve(null);
+    }
+  });
+}
+
+function idbRequest<T>(req: IDBRequest<T>): Promise<T | null> {
+  return new Promise((resolve) => {
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => resolve(null);
+  });
+}
+
+/** Sessions in the store, newest first. */
+export async function readPersistedSessions(): Promise<PersistedSession[]> {
+  const db = await openDb();
+  if (!db) return [];
+  try {
+    const tx = db.transaction(STORE, 'readonly');
+    const all = await idbRequest(tx.objectStore(STORE).getAll() as IDBRequest<PersistedSession[]>);
+    return (all ?? []).sort((a, b) => b.updatedAt - a.updatedAt);
+  } catch {
+    return [];
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * The most recent session that is not this one — i.e. what was lost to a
+ * reload. `closed: false` on it means the page went away without a clean
+ * shutdown, which is itself a strong diagnostic signal.
+ */
+export async function readPreviousSession(currentId: string): Promise<PersistedSession | null> {
+  const sessions = await readPersistedSessions();
+  return sessions.find((s) => s.id !== currentId) ?? null;
+}
+
+export interface LogPersistence {
+  sessionId: string;
+  flush(): Promise<void>;
+  /** Mark the session cleanly ended and stop persisting. */
+  close(): Promise<void>;
+}
+
+/**
+ * Start mirroring the log to IndexedDB.
+ *
+ * `sessionId` must be stable for the life of the page; the caller supplies it
+ * so the same id can be stamped into an exported bundle.
+ */
+export function startLogPersistence(sessionId: string): LogPersistence {
+  let pending: LogEntry[] = [];
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let stopped = false;
+  let closed = false;
+  let writing = false;
+
+  const unsubscribe = subscribeLog((entry) => {
+    pending.push(entry);
+  });
+
+  async function write(): Promise<void> {
+    // Overlapping writes would interleave read-modify-write on one record.
+    if (writing || stopped) return;
+    if (pending.length === 0 && !closed) return;
+    writing = true;
+    const batch = pending;
+    pending = [];
+    const db = await openDb();
+    if (!db) {
+      writing = false;
+      return;
+    }
+    try {
+      const tx = db.transaction(STORE, 'readwrite');
+      const store = tx.objectStore(STORE);
+      const existing = await idbRequest(store.get(sessionId) as IDBRequest<PersistedSession>);
+      const snap = logSnapshot();
+      const merged = [...(existing?.entries ?? []), ...batch];
+      const record: PersistedSession = {
+        id: sessionId,
+        startedAt: existing?.startedAt ?? snap.startedAt,
+        updatedAt: Date.now(),
+        // Keep the tail: after a crash the last entries are the interesting ones.
+        entries: merged.slice(-MAX_PERSISTED_ENTRIES),
+        closed,
+      };
+      store.put(record);
+
+      // Prune here rather than on a separate pass — this is the only writer.
+      const all = await idbRequest(store.getAll() as IDBRequest<PersistedSession[]>);
+      const ordered = (all ?? []).sort((a, b) => b.updatedAt - a.updatedAt);
+      for (const old of ordered.slice(MAX_SESSIONS)) store.delete(old.id);
+    } catch {
+      // Quota, private mode, or a closed connection. Persistence is a bonus.
+    } finally {
+      db.close();
+      writing = false;
+    }
+  }
+
+  const onVisibility = (): void => {
+    // The last reliable moment before a tab is discarded — `beforeunload` is
+    // not fired for crashes and is deliberately unused elsewhere in this app.
+    if (document.visibilityState === 'hidden') void write();
+  };
+  document.addEventListener('visibilitychange', onVisibility);
+  timer = setInterval(() => void write(), FLUSH_INTERVAL_MS);
+
+  return {
+    sessionId,
+    flush: write,
+    async close() {
+      closed = true;
+      await write();
+      stopped = true;
+      unsubscribe();
+      document.removeEventListener('visibilitychange', onVisibility);
+      if (timer !== null) clearInterval(timer);
+      timer = null;
+    },
+  };
+}
+
+/** Remove every persisted session (used by the report preview's discard path). */
+export async function clearPersistedSessions(): Promise<void> {
+  const db = await openDb();
+  if (!db) return;
+  try {
+    const tx = db.transaction(STORE, 'readwrite');
+    tx.objectStore(STORE).clear();
+  } catch {
+    // Best-effort.
+  } finally {
+    db.close();
+  }
+}

--- a/Software/Control/src/diagnostics/report.test.ts
+++ b/Software/Control/src/diagnostics/report.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildIssueFields,
+  buildIssueUrl,
+  bundleFileName,
+  environmentBlock,
+  ISSUE_URL_MAX,
+  ISSUE_TEMPLATE,
+  shortUserAgent,
+} from './report';
+import type { DiagnosticsBundle } from './exportBundle';
+import type { LogEntry } from './log';
+import { summariseForTriage } from './triage';
+
+function entry(over: Partial<LogEntry> = {}): LogEntry {
+  return {
+    seq: 1,
+    t: Date.UTC(2026, 0, 1, 12, 0, 0),
+    thread: 'main',
+    level: 'info',
+    cat: 'app',
+    tag: 'boot',
+    ...over,
+  };
+}
+
+function bundle(over: Partial<DiagnosticsBundle> = {}): DiagnosticsBundle {
+  const log = over.log ?? { entries: [], counters: {}, dropped: 0, startedAt: 0 };
+  return {
+    triage: summariseForTriage(log),
+    sessionId: 's-test',
+    generatedAt: '2026-01-01T12:00:00.000Z',
+    version: '0.1.0',
+    gitSha: 'abc1234',
+    userAgent: 'Mozilla/5.0 Chrome/130',
+    buildMode: 'production',
+    capabilities: { webSerial: true, fileSystemAccess: true },
+    device: {
+      connection: 'connected',
+      responding: true,
+      firmwareVersion: '1.2.3',
+      portLabel: 'USB 0403:6001',
+    },
+    worker: {},
+    log: { entries: [], counters: {}, dropped: 0, startedAt: 0 },
+    ...over,
+  };
+}
+
+describe('environmentBlock', () => {
+  it('leads with the build identity that makes a report actionable', () => {
+    const text = environmentBlock(bundle());
+    expect(text).toContain('App: 0.1.0 (abc1234)');
+    expect(text).toContain('Firmware: 1.2.3');
+  });
+
+  it('does not invent a firmware version when none is known', () => {
+    const text = environmentBlock(
+      bundle({ device: { connection: 'disconnected', responding: false, firmwareVersion: null, portLabel: null } }),
+    );
+    expect(text).toContain('Firmware: unknown');
+  });
+});
+
+describe('buildIssueFields', () => {
+  it('targets the issue template and names the attachment', () => {
+    const fields = buildIssueFields({ summary: 'jog does nothing' }, bundle(), 'mad-diagnostics-x.json');
+    expect(fields.template).toBe(ISSUE_TEMPLATE);
+    expect(fields.attachment).toBe('mad-diagnostics-x.json');
+    expect(fields.title).toContain('jog does nothing');
+  });
+
+  it('marks absent repro steps rather than sending an empty field', () => {
+    expect(buildIssueFields({ summary: 'x', steps: '   ' }, bundle(), 'f.json').steps).toBe('(not provided)');
+  });
+
+  it('surfaces only failure-ish counters, most frequent first', () => {
+    const fields = buildIssueFields({ summary: 'x' }, bundle({
+      log: {
+        entries: [],
+        counters: { 'proto:nack': 3, 'proto:tx': 900, 'proto:timeout': 7, 'app:boot': 1 },
+        dropped: 0,
+        startedAt: 0,
+      },
+    }), 'f.json');
+    expect(fields.counters).toBe('proto:timeout: 7\nproto:nack: 3');
+    expect(fields.counters).not.toContain('proto:tx');
+  });
+
+  it('says so plainly when nothing went wrong', () => {
+    const fields = buildIssueFields({ summary: 'x' }, bundle(), 'f.json');
+    expect(fields.counters).toMatch(/No errors/);
+    expect(fields.errors).toBe('None recorded.');
+  });
+
+  it('includes the most recent errors with timestamps', () => {
+    const fields = buildIssueFields({ summary: 'x' }, bundle({
+      log: {
+        entries: [
+          entry({ level: 'info', tag: 'boot' }),
+          entry({ level: 'error', cat: 'proto', tag: 'error', msg: 'bad crc' }),
+        ],
+        counters: {},
+        dropped: 0,
+        startedAt: 0,
+      },
+    }), 'f.json');
+    expect(fields.errors).toContain('proto/error bad crc');
+    expect(fields.errors).not.toContain('boot');
+  });
+});
+
+describe('buildIssueUrl', () => {
+  it('produces a template-targeted issue URL', () => {
+    const url = buildIssueUrl(buildIssueFields({ summary: 'broken' }, bundle(), 'f.json'));
+    expect(url.startsWith('https://github.com/RileyMcCarthy/MaD/issues/new?')).toBe(true);
+    expect(url).toContain(`template=${ISSUE_TEMPLATE}`);
+  });
+
+  it('stays under the URL budget even with a huge log', () => {
+    // A long session must not produce a link GitHub refuses to open.
+    const url = buildIssueUrl(
+      buildIssueFields(
+        { summary: 'x'.repeat(200), steps: 'y'.repeat(4000) },
+        bundle({
+          log: {
+            entries: Array.from({ length: 50 }, (_, i) =>
+              entry({ level: 'error', tag: `t${i}`, msg: 'z'.repeat(300) }),
+            ),
+            counters: Object.fromEntries(
+              Array.from({ length: 40 }, (_, i) => [`proto:error-${i}`, i]),
+            ),
+            dropped: 0,
+            startedAt: 0,
+          },
+        }),
+        'f.json',
+      ),
+    );
+    expect(url.length).toBeLessThanOrEqual(ISSUE_URL_MAX);
+  });
+
+  it("keeps the user's own words and drops derived blocks first", () => {
+    // Only `errors` is oversized here, so exactly one drop is needed — which is
+    // what pins the ordering: derived blocks go before anything the user typed.
+    const url = buildIssueUrl(
+      buildIssueFields(
+        { summary: 'the gantry stalls at 40mm', steps: 'jog to 40' },
+        bundle({
+          log: {
+            entries: Array.from({ length: 5 }, (_, i) =>
+              entry({ level: 'error', tag: `t${i}`, msg: 'q'.repeat(2000) }),
+            ),
+            counters: { 'proto:nack': 2 },
+            dropped: 0,
+            startedAt: 0,
+          },
+        }),
+        'f.json',
+      ),
+    );
+    const params = new URL(url).searchParams;
+    expect(url.length).toBeLessThanOrEqual(ISSUE_URL_MAX);
+    expect(params.get('errors')).toContain('omitted');
+    // Everything cheaper than `errors` survives untouched.
+    expect(params.get('summary')).toBe('the gantry stalls at 40mm');
+    expect(params.get('steps')).toBe('jog to 40');
+    expect(params.get('counters')).toBe('proto:nack: 2');
+  });
+
+  it('omits empty values instead of sending blank params', () => {
+    expect(buildIssueUrl({ title: 'a', steps: '' })).not.toContain('steps=');
+  });
+});
+
+describe('bundleFileName', () => {
+  it('is filesystem-safe and timestamped', () => {
+    const name = bundleFileName(new Date(Date.UTC(2026, 7, 20, 13, 45, 12, 345)));
+    expect(name).toBe('mad-diagnostics-2026-08-20T13-45-12-345Z.json');
+    expect(name).not.toMatch(/[:]/);
+  });
+});
+
+describe('buildIssueUrl under pathological input', () => {
+  it('fits the budget even when the summary alone dwarfs it', () => {
+    // A user can paste anything into the summary box; percent-encoding then
+    // expands it further. The link must still be one GitHub will open.
+    const url = buildIssueUrl(
+      buildIssueFields({ summary: 'x'.repeat(200_000) }, bundle(), 'f.json'),
+    );
+    expect(url.length).toBeLessThanOrEqual(ISSUE_URL_MAX);
+  });
+
+  it('fits when every character percent-expands', () => {
+    // Newlines and non-ASCII cost 3 bytes each once encoded — the case a
+    // single raw-length subtraction would undershoot.
+    const url = buildIssueUrl(
+      buildIssueFields({ summary: '\n…'.repeat(20_000) }, bundle(), 'f.json'),
+    );
+    expect(url.length).toBeLessThanOrEqual(ISSUE_URL_MAX);
+  });
+
+  it('still produces a usable issue link after truncation', () => {
+    const url = buildIssueUrl(buildIssueFields({ summary: 'q'.repeat(50_000) }, bundle(), 'f.json'));
+    const parsed = new URL(url);
+    expect(parsed.pathname).toBe('/RileyMcCarthy/MaD/issues/new');
+    expect(parsed.searchParams.get('template')).toBe(ISSUE_TEMPLATE);
+    expect((parsed.searchParams.get('summary') ?? '').length).toBeGreaterThan(0);
+  });
+});
+
+describe('shortUserAgent', () => {
+  it('reduces a UA string to something a human reads', () => {
+    expect(
+      shortUserAgent(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0 Safari/537.36',
+      ),
+    ).toBe('Chrome 130 on Intel Mac OS X 10_15_7');
+  });
+
+  it('names Edge as Edge rather than its Edg token', () => {
+    expect(shortUserAgent('Mozilla/5.0 (Windows NT 10.0) Chrome/130.0 Edg/130.0')).toContain('Edge 130');
+  });
+
+  it('degrades without throwing on an unrecognised UA', () => {
+    expect(shortUserAgent('something else entirely')).toBe('unknown browser');
+  });
+});
+
+describe('issue fields include the computed summary', () => {
+  it('carries a triage block the maintainer can read first', () => {
+    const fields = buildIssueFields({ summary: 'x' }, bundle(), 'f.json');
+    expect(typeof fields.triage).toBe('string');
+    expect(fields.triage.length).toBeGreaterThan(0);
+  });
+
+  it('drops the triage block before the user’s own words', () => {
+    const url = buildIssueUrl(
+      buildIssueFields(
+        { summary: 'the gantry stalls', steps: 'jog to 40' },
+        bundle({
+          log: {
+            entries: Array.from({ length: 5 }, (_, i) =>
+              entry({ level: 'error', tag: `t${i}`, msg: 'q'.repeat(2000) }),
+            ),
+            counters: {},
+            dropped: 0,
+            startedAt: 0,
+          },
+        }),
+        'f.json',
+      ),
+    );
+    const params = new URL(url).searchParams;
+    expect(params.get('summary')).toBe('the gantry stalls');
+    expect(params.get('steps')).toBe('jog to 40');
+  });
+});
+
+describe('shortUserAgent browser precedence', () => {
+  it('does not report Chrome for a Chromium-based browser', () => {
+    // Every Chromium UA contains "Chrome", so precedence is what makes this
+    // correct — a misattributed browser sends a bug hunt the wrong way.
+    expect(shortUserAgent('Mozilla/5.0 (X11) Chrome/130.0 Safari/537.36 OPR/115.0')).toContain('Opera 115');
+  });
+
+  it('reports Chrome for actual Chrome despite the Safari token', () => {
+    expect(
+      shortUserAgent('Mozilla/5.0 (Macintosh) AppleWebKit/537.36 Chrome/130.0 Safari/537.36'),
+    ).toContain('Chrome 130');
+  });
+
+  it('reports Safari for real Safari', () => {
+    expect(
+      shortUserAgent('Mozilla/5.0 (Macintosh) AppleWebKit/605.1 Version/17.4 Safari/605.1.15'),
+    ).toContain('Safari 17');
+  });
+});

--- a/Software/Control/src/diagnostics/report.ts
+++ b/Software/Control/src/diagnostics/report.ts
@@ -1,0 +1,295 @@
+/**
+ * "Report a bug" — turn a session into a filed GitHub issue.
+ *
+ * There is no backend and nowhere to hide a token, so the flow is: download the
+ * bundle locally, then open a prefilled issue form the user submits under their
+ * own account, attaching the file. Two steps, but zero infrastructure and no
+ * credential ever leaves the browser.
+ *
+ * The URL carries only a compact summary. GitHub rejects very long URLs, so the
+ * full log rides as the attachment — `buildIssueUrl` enforces that budget rather
+ * than letting a long session silently produce a dead link.
+ */
+
+import type { BundleOptions, DiagnosticsBundle } from './exportBundle';
+import { formatTriage } from './triage';
+import { logger } from './log';
+
+const log = logger('app');
+
+export const ISSUE_REPO = 'RileyMcCarthy/MaD';
+export const ISSUE_TEMPLATE = 'app-bug.yml';
+
+/**
+ * Practical ceiling for the issue URL. GitHub starts failing somewhere above
+ * 8 KB; 6 KB leaves room for the fields the form adds itself.
+ */
+export const ISSUE_URL_MAX = 6000;
+
+export interface ReportInput {
+  /** What the user says went wrong. */
+  summary: string;
+  /** Optional reproduction steps. */
+  steps?: string;
+  /** Attach the raw serial window (opt-in — see BundleOptions). */
+  includeSerialTail?: boolean;
+  /** Attach the previous page load's log (default on). */
+  includePreviousSession?: boolean;
+}
+
+/**
+ * What a bundle would disclose, for review before anything is published.
+ *
+ * The report ends up in a public issue, so the person filing it should be able
+ * to see the categories of information it carries — not just tick a box. This
+ * is derived from a real bundle rather than described from memory, so it cannot
+ * drift from what actually gets written.
+ */
+export interface ReportPreview {
+  bundle: DiagnosticsBundle;
+  triageText: string;
+  sizeBytes: number;
+  entryCount: number;
+  /** Human-readable lines describing what is included. */
+  contents: string[];
+  /** Identifying details worth a second look before publishing. */
+  disclosures: string[];
+}
+
+export async function buildReportPreview(input: ReportInput): Promise<ReportPreview> {
+  const { buildDiagnosticsBundle } = await import('./exportBundle');
+  const bundle = await buildDiagnosticsBundle({
+    includeSerialTail: input.includeSerialTail ?? false,
+    includePreviousSession: input.includePreviousSession ?? true,
+  });
+  const json = JSON.stringify(bundle);
+
+  const contents = [
+    `${bundle.log.entries.length} log entries (${(bundle.triage.sessionMs / 1000).toFixed(0)}s session)`,
+    `App version ${bundle.version} (${bundle.gitSha}), firmware ${bundle.device.firmwareVersion ?? 'unknown'}`,
+  ];
+  if (bundle.serialTail) {
+    contents.push(
+      `${bundle.serialTail.chunks.length} raw serial chunks (${bundle.serialTail.totalRxBytes} bytes received)`,
+    );
+  }
+  if (bundle.previousSession) {
+    contents.push(
+      `The previous session's log (${bundle.previousSession.entries.length} entries${
+        bundle.previousSession.closed ? '' : ', ended unexpectedly'
+      })`,
+    );
+  }
+
+  // Named explicitly: these are the fields that identify a machine or a person,
+  // and a checkbox alone is not informed consent for publishing them.
+  const disclosures = [`Your browser and OS version (${shortUserAgent(bundle.userAgent)})`];
+  if (bundle.device.portLabel) disclosures.push(`The serial adapter's USB id (${bundle.device.portLabel})`);
+  const folders = new Set(
+    bundle.log.entries
+      .filter((e) => e.cat === 'fs' && typeof e.data?.name === 'string')
+      .map((e) => String(e.data?.name)),
+  );
+  if (folders.size > 0) {
+    disclosures.push(`Data folder name${folders.size === 1 ? '' : 's'}: ${[...folders].join(', ')}`);
+  }
+  if (bundle.serialTail) {
+    disclosures.push('Raw bytes exchanged with the machine (no sample values or file contents)');
+  }
+
+  return {
+    bundle,
+    triageText: formatTriage(bundle.triage),
+    sizeBytes: json.length,
+    entryCount: bundle.log.entries.length,
+    contents,
+    disclosures,
+  };
+}
+
+/**
+ * `Chrome 130 on macOS` rather than the full 120-character UA string.
+ *
+ * Checked most-specific first: every Chromium UA contains `Chrome`, and
+ * Chrome's own contains `Safari`, so a plain alternation reports Edge as
+ * Chrome and would quietly misattribute a browser-specific bug.
+ */
+export function shortUserAgent(ua: string): string {
+  const CANDIDATES: Array<[RegExp, string]> = [
+    [/Edg\/(\d+)/, 'Edge'],
+    [/OPR\/(\d+)/, 'Opera'],
+    [/Firefox\/(\d+)/, 'Firefox'],
+    [/Chrome\/(\d+)/, 'Chrome'],
+    [/Version\/(\d+).*Safari/, 'Safari'],
+  ];
+  let name = 'unknown browser';
+  for (const [re, label] of CANDIDATES) {
+    const m = re.exec(ua);
+    if (m) {
+      name = `${label} ${m[1]}`;
+      break;
+    }
+  }
+  const os = /\((?:Macintosh; )?([^;)]+)/.exec(ua);
+  return os ? `${name} on ${os[1].trim()}` : name;
+}
+
+/** Counter lines worth putting in the issue body without the full log. */
+function summariseCounters(bundle: DiagnosticsBundle): string {
+  const counters = bundle.log.counters;
+  const interesting = Object.entries(counters)
+    .filter(([key]) => /error|nack|timeout|fail|trap|stall|jank/i.test(key))
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 12);
+  if (interesting.length === 0) return 'No errors, NACKs or timeouts recorded.';
+  return interesting.map(([key, n]) => `${key}: ${n}`).join('\n');
+}
+
+/** The last few error-level entries — usually the actual story. */
+function recentErrors(bundle: DiagnosticsBundle, limit = 5): string {
+  const errors = bundle.log.entries.filter((e) => e.level === 'error').slice(-limit);
+  if (errors.length === 0) return 'None recorded.';
+  return errors
+    .map((e) => {
+      const at = new Date(e.t).toISOString().slice(11, 23);
+      return `${at} ${e.cat}/${e.tag} ${e.msg ?? ''}`.trim();
+    })
+    .join('\n');
+}
+
+/**
+ * Environment block for the issue body.
+ *
+ * Deliberately not the raw user-agent string alone — the build identity is what
+ * decides whether a report is even actionable.
+ */
+export function environmentBlock(bundle: DiagnosticsBundle): string {
+  return [
+    `App: ${bundle.version} (${bundle.gitSha})`,
+    `Mode: ${bundle.buildMode}`,
+    `Firmware: ${bundle.device.firmwareVersion ?? 'unknown'}`,
+    `Connection: ${bundle.device.connection}${bundle.device.responding ? ' (responding)' : ''}`,
+    `Web Serial: ${bundle.capabilities.webSerial ? 'yes' : 'no'} · File System Access: ${
+      bundle.capabilities.fileSystemAccess ? 'yes' : 'no'
+    }`,
+    `UA: ${bundle.userAgent}`,
+  ].join('\n');
+}
+
+/** Fields posted to the issue form, keyed by the template's field ids. */
+export function buildIssueFields(
+  input: ReportInput,
+  bundle: DiagnosticsBundle,
+  attachmentName: string,
+): Record<string, string> {
+  return {
+    template: ISSUE_TEMPLATE,
+    labels: 'bug,app',
+    title: `[app] ${input.summary.slice(0, 80)}`,
+    summary: input.summary,
+    steps: input.steps?.trim() ? input.steps : '(not provided)',
+    environment: environmentBlock(bundle),
+    triage: formatTriage(bundle.triage),
+    counters: summariseCounters(bundle),
+    errors: recentErrors(bundle),
+    attachment: attachmentName,
+  };
+}
+
+/**
+ * Build the prefilled issue URL, trimming the longest optional fields until it
+ * fits the budget.
+ *
+ * Trimming order is deliberate: `steps` and `summary` are the user's own words
+ * and are dropped last; the derived blocks are reconstructible from the
+ * attachment, so they go first.
+ */
+export function buildIssueUrl(fields: Record<string, string>): string {
+  const base = `https://github.com/${ISSUE_REPO}/issues/new`;
+  const droppable = ['errors', 'counters', 'environment', 'triage', 'steps'];
+
+  const render = (f: Record<string, string>): string => {
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(f)) {
+      if (value !== '') params.set(key, value);
+    }
+    return `${base}?${params.toString()}`;
+  };
+
+  const working = { ...fields };
+  let url = render(working);
+  for (const key of droppable) {
+    if (url.length <= ISSUE_URL_MAX) break;
+    if (working[key] === undefined) continue;
+    working[key] = '(omitted — see attached diagnostics file)';
+    url = render(working);
+  }
+
+  // Last resort: truncate the summary itself. Iterative rather than a single
+  // subtraction, because percent-encoding can expand one character into three —
+  // trimming by the raw overflow would undershoot on a summary full of newlines
+  // or non-ASCII. Halving converges in a handful of passes.
+  const SUMMARY_FLOOR = 40;
+  let guard = 24;
+  while (url.length > ISSUE_URL_MAX && guard > 0) {
+    const current = working.summary ?? '';
+    if (current.length <= SUMMARY_FLOOR) break;
+    const next = Math.max(SUMMARY_FLOOR, Math.floor(current.length / 2));
+    working.summary = current.slice(0, next);
+    url = render(working);
+    guard -= 1;
+  }
+  return url;
+}
+
+/** Timestamped bundle filename, matching what the issue body tells the user to attach. */
+export function bundleFileName(now: Date): string {
+  return `mad-diagnostics-${now.toISOString().replace(/[:.]/g, '-')}.json`;
+}
+
+function downloadJson(name: string, data: unknown): void {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = name;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+export interface ReportResult {
+  fileName: string;
+  issueUrl: string;
+  bundle: DiagnosticsBundle;
+}
+
+/**
+ * Download the bundle and open the prefilled issue.
+ *
+ * The download happens first: if the popup is blocked, the user still has the
+ * file and the returned URL, so the report is never lost to a blocked tab.
+ */
+export async function fileBugReport(
+  input: ReportInput,
+  reviewed?: ReportPreview,
+): Promise<ReportResult> {
+  // Publish exactly what was reviewed. Rebuilding here would attach a bundle
+  // the user never saw — including any entries logged while they were reading
+  // the preview.
+  const preview = reviewed ?? (await buildReportPreview(input));
+  const bundle = preview.bundle;
+  const opts: BundleOptions = { includeSerialTail: input.includeSerialTail ?? false };
+  const fileName = bundleFileName(new Date());
+
+  log.info('bug-report', 'filed', {
+    entries: bundle.log.entries.length,
+    includeSerialTail: opts.includeSerialTail,
+  });
+
+  downloadJson(fileName, bundle);
+  const issueUrl = buildIssueUrl(buildIssueFields(input, bundle, fileName));
+  window.open(issueUrl, '_blank', 'noopener,noreferrer');
+  return { fileName, issueUrl, bundle };
+}

--- a/Software/Control/src/diagnostics/triage.test.ts
+++ b/Software/Control/src/diagnostics/triage.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { summariseForTriage, formatTriage } from './triage';
+import type { LogEntry, LogSnapshot } from './log';
+
+let seq = 0;
+function e(over: Partial<LogEntry> = {}): LogEntry {
+  seq += 1;
+  return {
+    seq,
+    t: Date.UTC(2026, 0, 1, 12, 0, 0) + seq * 1000,
+    thread: 'main',
+    level: 'info',
+    cat: 'app',
+    tag: 'boot',
+    ...over,
+  };
+}
+
+const snap = (entries: LogEntry[], over: Partial<LogSnapshot> = {}): LogSnapshot => ({
+  entries,
+  counters: {},
+  dropped: 0,
+  startedAt: Date.UTC(2026, 0, 1, 12, 0, 0),
+  ...over,
+});
+
+describe('summariseForTriage', () => {
+  it('says plainly when nothing went wrong', () => {
+    const t = summariseForTriage(
+      snap([e({ cat: 'store', tag: 'connected' }), e({ cat: 'perf', tag: 'stream' })]),
+    );
+    expect(t.headline).toMatch(/No errors/);
+    expect(t.flags).toEqual([]);
+    expect(t.counts.errors).toBe(0);
+  });
+
+  it('reports the first error and the last separately', () => {
+    // The first is usually the cause and the last usually a symptom, so a
+    // report showing only one of them misleads.
+    const t = summariseForTriage(
+      snap([
+        e({ level: 'error', cat: 'proto', tag: 'error', msg: 'bad crc' }),
+        e({ level: 'error', cat: 'device', tag: 'link-lost', msg: 'gone' }),
+      ]),
+    );
+    expect(t.firstError?.msg).toBe('bad crc');
+    expect(t.lastError?.msg).toBe('gone');
+  });
+
+  it('flags never having connected', () => {
+    const t = summariseForTriage(snap([e()]));
+    expect(t.everConnected).toBe(false);
+    expect(t.flags).toContain('never connected to a device');
+  });
+
+  it('distinguishes connected-but-silent from never connected', () => {
+    const t = summariseForTriage(snap([e({ cat: 'store', tag: 'connected' })]));
+    expect(t.everConnected).toBe(true);
+    expect(t.everResponded).toBe(false);
+    expect(t.flags).toContain('connected but the device never sent samples');
+  });
+
+  it('surfaces undecodable traffic with an actionable hint', () => {
+    const t = summariseForTriage(
+      snap([e({ cat: 'store', tag: 'connected' }), e({ level: 'error', cat: 'proto', tag: 'undecodable' })]),
+    );
+    expect(t.undecodableTraffic).toBe(true);
+    expect(t.flags.join(' ')).toMatch(/baud rate, wiring, or firmware/);
+  });
+
+  it('makes log truncation visible', () => {
+    const t = summariseForTriage(snap([e()], { dropped: 120 }));
+    expect(t.flags.join(' ')).toContain('120 entries evicted');
+  });
+
+  it('ranks failure counters worst-first and ignores healthy ones', () => {
+    const t = summariseForTriage(
+      snap([e()], { counters: { 'proto:nack': 2, 'proto:tx': 900, 'proto:timeout': 9 } }),
+    );
+    expect(t.topFailures).toEqual([
+      { tag: 'proto:timeout', count: 9 },
+      { tag: 'proto:nack', count: 2 },
+    ]);
+  });
+
+  it('picks up a failed firmware flash', () => {
+    const t = summariseForTriage(snap([e({ level: 'error', cat: 'flash', tag: 'failed' })]));
+    expect(t.flags).toContain('a firmware flash failed');
+  });
+
+  it('carries the last observed sample rate', () => {
+    const t = summariseForTriage(
+      snap([e({ cat: 'perf', tag: 'stream', data: { rateHz: 99.4 } })]),
+    );
+    expect(t.lastSampleRateHz).toBe(99.4);
+  });
+
+  it('survives an empty log', () => {
+    const t = summariseForTriage(snap([]));
+    expect(t.entries).toBe(0);
+    expect(t.sessionMs).toBe(0);
+    expect(() => formatTriage(t)).not.toThrow();
+  });
+});
+
+describe('formatTriage', () => {
+  it('leads with the verdict and includes the flags', () => {
+    const text = formatTriage(
+      summariseForTriage(
+        snap([
+          e({ cat: 'store', tag: 'connected' }),
+          e({ level: 'error', cat: 'proto', tag: 'undecodable', msg: 'garbage' }),
+        ]),
+      ),
+    );
+    expect(text.split('\n')[0]).toMatch(/1 error/);
+    expect(text).toContain('baud rate');
+    expect(text).toContain('First error: proto/undecodable');
+  });
+
+  it('does not repeat a single error as both first and last', () => {
+    const text = formatTriage(
+      summariseForTriage(snap([e({ level: 'error', cat: 'proto', tag: 'error', msg: 'only' })])),
+    );
+    expect(text.match(/only/g)?.length).toBe(1);
+  });
+});

--- a/Software/Control/src/diagnostics/triage.ts
+++ b/Software/Control/src/diagnostics/triage.ts
@@ -1,0 +1,133 @@
+/**
+ * Computed triage summary for a diagnostics bundle.
+ *
+ * A maintainer opening a report should not have to read 5000 entries to find
+ * out whether the link ever worked. This answers the first questions up front —
+ * did it connect, did it stay healthy, what failed first, what failed most —
+ * so the raw timeline becomes something you consult rather than something you
+ * have to scan.
+ *
+ * Everything here is derived from the log; it adds no new capture.
+ */
+
+import type { LogEntry, LogSnapshot } from './log';
+
+export interface TriageSummary {
+  /** One-line verdict, suitable for an issue title or the top of a comment. */
+  headline: string;
+  sessionMs: number;
+  entries: number;
+  /** Entries evicted by ring wrap — a nonzero value means the log is truncated. */
+  dropped: number;
+  counts: { errors: number; warnings: number };
+  /** Most frequent failure tags, worst first. */
+  topFailures: Array<{ tag: string; count: number }>;
+  firstError?: { at: number; tag: string; msg: string };
+  lastError?: { at: number; tag: string; msg: string };
+  /** Whether the app ever reached a working link this session. */
+  everConnected: boolean;
+  everResponded: boolean;
+  /** Set when bytes arrived that never decoded — almost always baud or wiring. */
+  undecodableTraffic: boolean;
+  /** Observed sample rate from the last healthy aggregate, if any. */
+  lastSampleRateHz?: number;
+  /** Signals worth reading before anything else. */
+  flags: string[];
+}
+
+const FAILURE_KEY = /error|nack|timeout|fail|trap|stall|jank|undecodable|abort|refus|reject/i;
+
+function describe(e: LogEntry): { at: number; tag: string; msg: string } {
+  return { at: e.t, tag: `${e.cat}/${e.tag}`, msg: e.msg ?? '' };
+}
+
+export function summariseForTriage(log: LogSnapshot): TriageSummary {
+  const entries = log.entries;
+  const errors = entries.filter((e) => e.level === 'error');
+  const warnings = entries.filter((e) => e.level === 'warn');
+
+  const has = (cat: string, tag: string): boolean =>
+    entries.some((e) => e.cat === cat && e.tag === tag);
+
+  const topFailures = Object.entries(log.counters)
+    .filter(([key]) => FAILURE_KEY.test(key))
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 8)
+    .map(([tag, count]) => ({ tag, count }));
+
+  const everConnected = has('store', 'connected') || has('device', 'connect');
+  const undecodableTraffic = has('proto', 'undecodable');
+  // A responding link is one that produced decoded sample traffic.
+  const perf = entries.filter((e) => e.cat === 'perf' && e.tag === 'stream');
+  const everResponded = perf.length > 0;
+  const lastRate = perf[perf.length - 1]?.data?.rateHz;
+
+  const flags: string[] = [];
+  if (!everConnected) flags.push('never connected to a device');
+  else if (!everResponded) flags.push('connected but the device never sent samples');
+  if (undecodableTraffic) {
+    flags.push('received bytes that never decoded — suspect baud rate, wiring, or firmware');
+  }
+  if (has('wasm', 'poll-trap')) flags.push('the protocol core trapped (WASM panic)');
+  if (has('ui', 'render-crash')) flags.push('a screen crashed while rendering');
+  if (has('flash', 'failed')) flags.push('a firmware flash failed');
+  if (has('app', 'stall') || has('app', 'jank')) flags.push('the main thread stalled');
+  if (log.dropped > 0) flags.push(`log truncated — ${log.dropped} entries evicted`);
+
+  const sessionMs =
+    entries.length > 0 ? Math.round(entries[entries.length - 1].t - log.startedAt) : 0;
+
+  const headline =
+    errors.length === 0 && flags.length === 0
+      ? 'No errors recorded this session.'
+      : [
+          errors.length > 0 ? `${errors.length} error${errors.length === 1 ? '' : 's'}` : '',
+          warnings.length > 0 ? `${warnings.length} warning${warnings.length === 1 ? '' : 's'}` : '',
+          flags[0] ?? '',
+        ]
+          .filter(Boolean)
+          .join(' · ');
+
+  const summary: TriageSummary = {
+    headline,
+    sessionMs,
+    entries: entries.length,
+    dropped: log.dropped,
+    counts: { errors: errors.length, warnings: warnings.length },
+    topFailures,
+    everConnected,
+    everResponded,
+    undecodableTraffic,
+    flags,
+  };
+  if (errors.length > 0) {
+    // The FIRST error is usually the cause and the last is usually a symptom,
+    // so a report that shows only one of them tends to mislead.
+    summary.firstError = describe(errors[0]);
+    summary.lastError = describe(errors[errors.length - 1]);
+  }
+  if (typeof lastRate === 'number') summary.lastSampleRateHz = lastRate;
+  return summary;
+}
+
+/** Render the summary as plain text for an issue body or a terminal. */
+export function formatTriage(t: TriageSummary): string {
+  const lines = [
+    t.headline,
+    `Session: ${(t.sessionMs / 1000).toFixed(1)}s · ${t.entries} entries${
+      t.dropped > 0 ? ` (+${t.dropped} evicted)` : ''
+    }`,
+    `Link: ${t.everConnected ? 'connected' : 'never connected'}${
+      t.everConnected ? (t.everResponded ? ', device responded' : ', device never responded') : ''
+    }${t.lastSampleRateHz !== undefined ? ` · ${t.lastSampleRateHz} Hz` : ''}`,
+  ];
+  if (t.flags.length > 0) lines.push('', 'Flags:', ...t.flags.map((f) => `  - ${f}`));
+  if (t.firstError) lines.push('', `First error: ${t.firstError.tag} ${t.firstError.msg}`.trim());
+  if (t.lastError && t.lastError.at !== t.firstError?.at) {
+    lines.push(`Last error:  ${t.lastError.tag} ${t.lastError.msg}`.trim());
+  }
+  if (t.topFailures.length > 0) {
+    lines.push('', 'Failure counts:', ...t.topFailures.map((f) => `  ${f.tag}: ${f.count}`));
+  }
+  return lines.join('\n');
+}

--- a/Software/Control/src/firmware/p2loader.ts
+++ b/Software/Control/src/firmware/p2loader.ts
@@ -41,6 +41,24 @@ export interface P2Transport {
   drain(): Promise<void>;
 }
 
+/**
+ * Progress/diagnostic events emitted during a load.
+ *
+ * A callback rather than a logger import: this module is deliberately
+ * dependency-free so `tools/hw-p2load.mts` can drive the identical protocol
+ * headlessly. The caller decides what (if anything) to do with these.
+ */
+export type LoaderEvent =
+  | { kind: 'reset' }
+  | { kind: 'detect-attempt'; attempt: number; retries: number }
+  | { kind: 'detect-reply'; attempt: number; bytes: number; text: string }
+  | { kind: 'detected'; version: string; attempt: number }
+  | { kind: 'upload-begin'; bytes: number; chunks: number; verifyChecksum: boolean }
+  | { kind: 'upload-progress'; sent: number; total: number }
+  | { kind: 'verify'; ok: boolean; reply: string };
+
+export type LoaderEventSink = (event: LoaderEvent) => void;
+
 export class P2LoaderError extends Error {
   constructor(
     message: string,
@@ -80,19 +98,29 @@ export async function hardwareReset(t: P2Transport): Promise<void> {
  *
  * @returns the single-character ROM version ('G' on shipping silicon).
  */
-export async function detectP2(t: P2Transport, retries = 5): Promise<string> {
+export async function detectP2(
+  t: P2Transport,
+  retries = 5,
+  onEvent?: LoaderEventSink,
+): Promise<string> {
+  onEvent?.({ kind: 'reset' });
   await hardwareReset(t);
   await delay(20); // let the ROM come up before probing
 
   for (let i = 0; i < retries; i++) {
+    onEvent?.({ kind: 'detect-attempt', attempt: i + 1, retries });
     await t.flushInput();
     await t.write(ascii(CHK_COMMAND));
     await t.drain();
     const reply = await t.read(20, 200);
     const text = new TextDecoder('latin1').decode(reply);
+    // What the ROM actually said is the whole diagnosis when it says the wrong
+    // thing — silence means wiring, garbage means baud or a busy port.
+    onEvent?.({ kind: 'detect-reply', attempt: i + 1, bytes: reply.length, text });
     const m = /^\r\nProp_Ver (.)/.exec(text);
     if (m) {
       const version = m[1];
+      onEvent?.({ kind: 'detected', version, attempt: i + 1 });
       // 'B' is the old FPGA image; it speaks a different load protocol.
       if (version === 'B') {
         throw new P2LoaderError(
@@ -136,6 +164,8 @@ export interface LoadOptions {
   verifyChecksum?: boolean;
   /** Called with bytes-sent / total so the UI can show progress. */
   onProgress?: (sent: number, total: number) => void;
+  /** Diagnostic events for the session log; see {@link LoaderEvent}. */
+  onEvent?: LoaderEventSink;
   signal?: AbortSignal;
 }
 
@@ -148,12 +178,18 @@ export interface LoadOptions {
 export async function loadImage(
   t: P2Transport,
   image: Uint8Array,
-  { verifyChecksum = true, onProgress, signal }: LoadOptions = {},
+  { verifyChecksum = true, onProgress, onEvent, signal }: LoadOptions = {},
 ): Promise<void> {
   if (image.byteLength % 4 !== 0) {
     throw new P2LoaderError('Image length must be a multiple of 4 bytes.', 'rejected');
   }
 
+  onEvent?.({
+    kind: 'upload-begin',
+    bytes: image.byteLength,
+    chunks: Math.ceil(image.byteLength / CHUNK_BYTES),
+    verifyChecksum,
+  });
   await t.write(ascii(HEX_COMMAND));
 
   let checksum = 0;
@@ -163,6 +199,7 @@ export async function loadImage(
     if (verifyChecksum) checksum = (checksum + sumLongs(chunk)) >>> 0;
     await t.write(ascii(toHexLine(chunk) + ' > '));
     onProgress?.(off + chunk.byteLength, image.byteLength);
+    onEvent?.({ kind: 'upload-progress', sent: off + chunk.byteLength, total: image.byteLength });
   }
 
   if (!verifyChecksum) {
@@ -181,6 +218,7 @@ export async function loadImage(
   await t.drain();
 
   const reply = new TextDecoder('latin1').decode(await t.read(1, 300));
+  onEvent?.({ kind: 'verify', ok: reply === '.', reply });
   if (reply !== '.') {
     throw new P2LoaderError(
       `The Propeller 2 rejected the image (expected ".", got ${JSON.stringify(reply)}). ` +

--- a/Software/Control/src/firmware/program.ts
+++ b/Software/Control/src/firmware/program.ts
@@ -3,8 +3,77 @@
  * the right image, stream it, hand the port back.
  */
 import { buildFlashImage, buildRamImage } from './image';
-import { detectP2, loadImage, type P2Transport } from './p2loader';
+import { detectP2, loadImage, type LoaderEvent, type P2Transport } from './p2loader';
 import { LOADER_BAUD_RATE, WebSerialTransport } from './webSerialTransport';
+import { logger, nowMs } from '@/diagnostics/log';
+
+const log = logger('flash');
+
+/** Progress is logged at decile boundaries — a full image is ~4000 chunks. */
+const PROGRESS_STEP = 0.1;
+
+/**
+ * Translate loader events into log entries.
+ *
+ * Flashing is the longest, most failure-prone serial operation in the app and
+ * it runs against the boot ROM rather than the MaD protocol, so none of the
+ * `proto` instrumentation covers it. Without this a "flashing failed" report
+ * contains nothing at all about the flash.
+ */
+function makeLoaderLogger(): (event: LoaderEvent) => void {
+  let nextProgress = PROGRESS_STEP;
+  return (event) => {
+    switch (event.kind) {
+      case 'reset':
+        log.info('reset', 'pulsing DTR to reset the P2');
+        break;
+      case 'detect-attempt':
+        log.debug('detect', 'probing boot ROM', {
+          attempt: event.attempt,
+          retries: event.retries,
+        });
+        break;
+      case 'detect-reply':
+        // Silence means wiring; garbage means baud or a port someone else holds.
+        // Either way the raw reply is the diagnosis, so keep it printable.
+        if (event.bytes > 0) {
+          log.debug('detect-reply', undefined, {
+            attempt: event.attempt,
+            bytes: event.bytes,
+            reply: JSON.stringify(event.text),
+          });
+        }
+        break;
+      case 'detected':
+        log.info('detected', `ROM version ${event.version}`, { attempt: event.attempt });
+        break;
+      case 'upload-begin':
+        nextProgress = PROGRESS_STEP;
+        log.info('upload-begin', undefined, {
+          bytes: event.bytes,
+          chunks: event.chunks,
+          verifyChecksum: event.verifyChecksum,
+        });
+        break;
+      case 'upload-progress': {
+        const fraction = event.total > 0 ? event.sent / event.total : 1;
+        if (fraction < nextProgress) break;
+        nextProgress = Math.floor(fraction / PROGRESS_STEP) * PROGRESS_STEP + PROGRESS_STEP;
+        log.debug('upload', `${Math.round(fraction * 100)}%`, {
+          sent: event.sent,
+          total: event.total,
+        });
+        break;
+      }
+      case 'verify':
+        if (event.ok) log.info('verify', 'checksum accepted');
+        else log.error('verify', 'checksum rejected', { reply: JSON.stringify(event.reply) });
+        break;
+      default:
+        break;
+    }
+  };
+}
 
 export type ProgramMode = 'ram' | 'flash';
 
@@ -40,24 +109,51 @@ export async function programTransport(
   firmware: Uint8Array,
   { mode, onProgress, signal }: ProgramOptions,
 ): Promise<ProgramResult> {
-  onProgress?.({ phase: 'resetting' });
-  const romVersion = await detectP2(transport);
-  signal?.throwIfAborted();
+  const onEvent = makeLoaderLogger();
+  const startedAt = nowMs();
+  let phase: ProgramPhase = 'resetting';
+  log.info('start', `programming to ${mode}`, { mode, firmwareBytes: firmware.byteLength });
 
-  const image = mode === 'flash' ? buildFlashImage(firmware) : buildRamImage(firmware);
+  try {
+    onProgress?.({ phase: 'resetting' });
+    const romVersion = await detectP2(transport, 5, onEvent);
+    signal?.throwIfAborted();
 
-  onProgress?.({ phase: 'uploading', sent: 0, total: image.byteLength });
-  await loadImage(transport, image, {
-    // loadp2 disables the ROM checksum handshake when the payload is the flash
-    // stub — the running sum collides with the stub's own header checksum.
-    verifyChecksum: mode === 'ram',
-    onProgress: (sent, total) => onProgress?.({ phase: 'uploading', sent, total }),
-    signal,
-  });
+    const image = mode === 'flash' ? buildFlashImage(firmware) : buildRamImage(firmware);
 
-  onProgress?.({ phase: 'verifying' });
-  onProgress?.({ phase: 'done' });
-  return { romVersion, imageBytes: image.byteLength };
+    phase = 'uploading';
+    onProgress?.({ phase: 'uploading', sent: 0, total: image.byteLength });
+    await loadImage(transport, image, {
+      // loadp2 disables the ROM checksum handshake when the payload is the flash
+      // stub — the running sum collides with the stub's own header checksum.
+      verifyChecksum: mode === 'ram',
+      onProgress: (sent, total) => onProgress?.({ phase: 'uploading', sent, total }),
+      onEvent,
+      signal,
+    });
+
+    phase = 'verifying';
+    onProgress?.({ phase: 'verifying' });
+    onProgress?.({ phase: 'done' });
+    log.info('done', 'programming complete', {
+      mode,
+      romVersion,
+      imageBytes: image.byteLength,
+      durMs: Math.round(nowMs() - startedAt),
+    });
+    return { romVersion, imageBytes: image.byteLength };
+  } catch (err) {
+    // Which phase it died in is the first question: reset/detect points at
+    // wiring or a busy port, upload at the link, verify at dropped bytes.
+    log.error('failed', err instanceof Error ? err.message : String(err), {
+      mode,
+      phase,
+      code: (err as { code?: string }).code,
+      aborted: signal?.aborted ?? false,
+      durMs: Math.round(nowMs() - startedAt),
+    });
+    throw err;
+  }
 }
 
 /**

--- a/Software/Control/src/store/useStore.ts
+++ b/Software/Control/src/store/useStore.ts
@@ -138,6 +138,35 @@ function logStateTransition(prev: MachineState | null, next: MachineState): void
 }
 
 /**
+ * Field-level diff of two machine configurations, as `field: "old→new"`.
+ *
+ * Only changed scalar fields survive, so a 30-field config that had one value
+ * edited logs one key. Nested values are compared by JSON so a changed
+ * sub-object still shows up rather than silently passing an identity check.
+ */
+function diffConfig(
+  prev: MachineConfiguration | null,
+  next: MachineConfiguration,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (prev === null) return { _initial: 'no previous config' };
+  const keys = new Set([...Object.keys(prev), ...Object.keys(next)]);
+  for (const key of keys) {
+    const a = (prev as unknown as Record<string, unknown>)[key];
+    const b = (next as unknown as Record<string, unknown>)[key];
+    const sameByValue =
+      typeof a === 'object' || typeof b === 'object'
+        ? JSON.stringify(a) === JSON.stringify(b)
+        : a === b;
+    if (sameByValue) continue;
+    const show = (v: unknown): string =>
+      typeof v === 'object' && v !== null ? JSON.stringify(v).slice(0, 60) : String(v);
+    out[key] = `${show(a)}→${show(b)}`;
+  }
+  return out;
+}
+
+/**
  * Log whether a device command actually succeeded.
  *
  * Intent alone is misleading: "user pressed jog" next to silence reads like the
@@ -486,11 +515,24 @@ export const useStore = create<AppState>((set, getState) => ({
 
   reconnect: async () => {
     const s = getState();
-    if (s.connection !== 'disconnected') return;
+    if (s.connection !== 'disconnected') {
+      logStore.debug('reconnect', 'skipped — not disconnected', { connection: s.connection });
+      return;
+    }
     // Re-resolve via getPorts() (a replug yields a fresh SerialPort object; the
     // cached lastPort handle may be stale); fall back to the cached handle.
-    const port = (await findGrantedPortForPref(readSerialPref())) ?? lastPort;
-    if (!port) return;
+    const resolved = await findGrantedPortForPref(readSerialPref());
+    const port = resolved ?? lastPort;
+    if (!port) {
+      // The usual cause of "Reconnect does nothing": the browser dropped the
+      // port grant, so there is nothing to reconnect to without a user gesture.
+      logStore.warn('reconnect', 'no granted port available');
+      return;
+    }
+    logStore.info('reconnect', 'retrying last port', {
+      source: resolved ? 'getPorts' : 'cached handle',
+      baud: lastBaud,
+    });
     await s.connect({ port, baud: lastBaud });
   },
 
@@ -531,7 +573,16 @@ export const useStore = create<AppState>((set, getState) => ({
   },
 
   saveConfig: async (config) => {
+    // Field-level diff, not the whole object: a wrong machine configuration is
+    // a common silent root cause, and "what did they actually change" is the
+    // question a report needs to answer. Values are plain numbers/strings.
+    const changed = diffConfig(getState().config, config);
+    logStore.info('saveConfig', undefined, {
+      changedCount: Object.keys(changed).length,
+      ...changed,
+    });
     const ok = await deviceClient.writeMachineConfiguration(config);
+    logStore.info('saveConfig', ok ? 'accepted' : 'rejected', { ok });
     if (ok) set({ config });
     return ok;
   },

--- a/Software/Control/src/styles.css
+++ b/Software/Control/src/styles.css
@@ -283,13 +283,20 @@ label.field {
 }
 
 input,
-select {
+select,
+textarea {
   font: inherit;
   background: var(--bg);
   color: var(--text);
   border: 1px solid var(--border);
   border-radius: 8px;
   padding: 8px 10px;
+}
+
+/* Multi-line fields size vertically only — horizontal drag would break the
+ * surrounding flex layout. */
+textarea {
+  resize: vertical;
 }
 
 /* Drop the native select chrome so the box renders exactly as styled and the

--- a/Software/Control/src/ui/screens/About.tsx
+++ b/Software/Control/src/ui/screens/About.tsx
@@ -1,19 +1,49 @@
 import { useState } from 'react';
 import { useStore } from '@/store/useStore';
-import { downloadDiagnostics } from '@/diagnostics/exportBundle';
+import { buildReportPreview, fileBugReport, type ReportPreview } from '@/diagnostics/report';
 
 export default function About() {
   const fw = useStore((s) => s.firmwareVersion);
   const connected = useStore((s) => s.connection === 'connected');
   const responding = useStore((s) => s.responding);
-  const [exporting, setExporting] = useState(false);
 
-  const exportDiagnostics = async () => {
-    setExporting(true);
+  const [summary, setSummary] = useState('');
+  const [steps, setSteps] = useState('');
+  const [includeSerialTail, setIncludeSerialTail] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [preview, setPreview] = useState<ReportPreview | null>(null);
+  const [filed, setFiled] = useState<{ fileName: string; issueUrl: string } | null>(null);
+  const [failed, setFailed] = useState<string | null>(null);
+
+  const input = { summary, steps, includeSerialTail };
+
+  // Two steps on purpose: this ends up in a public issue, so the contents are
+  // shown before anything is written or a tab is opened.
+  const review = async () => {
+    setBusy(true);
+    setFailed(null);
     try {
-      await downloadDiagnostics();
+      setPreview(await buildReportPreview(input));
+    } catch (err) {
+      setFailed(err instanceof Error ? err.message : String(err));
     } finally {
-      setExporting(false);
+      setBusy(false);
+    }
+  };
+
+  const submit = async () => {
+    if (!preview) return;
+    setBusy(true);
+    setFailed(null);
+    try {
+      // Pass the reviewed bundle through, so what is published is what was seen.
+      const result = await fileBugReport(input, preview);
+      setFiled({ fileName: result.fileName, issueUrl: result.issueUrl });
+      setPreview(null);
+    } catch (err) {
+      setFailed(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
     }
   };
 
@@ -49,14 +79,114 @@ export default function About() {
       </div>
 
       <div className="panel">
-        <h2>Diagnostics</h2>
+        <h2>Report a bug</h2>
         <p className="muted">
-          Export a session log (connection events, protocol errors/timeouts, and throughput
-          counters) to help debug a hardware issue. No sample data or file contents are included.
+          Saves this session&apos;s log — connection events, protocol traffic, errors and
+          timings — then opens a pre-filled GitHub issue. Attach the downloaded file to the
+          issue so the problem can be traced without reproducing it.
         </p>
-        <button onClick={() => void exportDiagnostics()} disabled={exporting} data-testid="export-diagnostics">
-          {exporting ? 'Preparing…' : 'Download diagnostics'}
-        </button>
+
+        <label className="field">
+          What went wrong?
+          <input
+            type="text"
+            value={summary}
+            placeholder="e.g. jogging stops responding after a test"
+            onChange={(e) => setSummary(e.target.value)}
+            data-testid="report-summary"
+          />
+        </label>
+
+        <label className="field">
+          Steps to reproduce (optional)
+          <textarea
+            rows={3}
+            value={steps}
+            placeholder={'1. Connect\n2. Run a test\n3. Try to jog'}
+            onChange={(e) => setSteps(e.target.value)}
+            data-testid="report-steps"
+          />
+        </label>
+
+        <label className="row" style={{ gap: 8, alignItems: 'center' }}>
+          <input
+            type="checkbox"
+            checked={includeSerialTail}
+            onChange={(e) => setIncludeSerialTail(e.target.checked)}
+            data-testid="report-include-serial"
+          />
+          <span>
+            Include the raw serial window
+            <span className="muted"> — needed for protocol bugs; no sample values or file contents</span>
+          </span>
+        </label>
+
+        <div className="row" style={{ marginTop: 12 }}>
+          <button
+            className="primary"
+            onClick={() => void review()}
+            disabled={busy || summary.trim() === ''}
+            data-testid="report-review"
+          >
+            {busy && !preview ? 'Preparing…' : 'Review report'}
+          </button>
+        </div>
+
+        {preview && (
+          <div className="panel card" style={{ marginTop: 12 }} data-testid="report-preview">
+            <h3 style={{ marginTop: 0 }}>What will be sent</h3>
+            <pre className="code-block" style={{ maxHeight: 180 }} data-testid="report-triage">
+              {preview.triageText}
+            </pre>
+            <p className="muted" style={{ marginBottom: 4 }}>Included:</p>
+            <ul className="muted" style={{ marginTop: 0 }}>
+              {preview.contents.map((line) => (
+                <li key={line}>{line}</li>
+              ))}
+            </ul>
+            <p className="muted" style={{ marginBottom: 4 }}>
+              Identifying details — this becomes a public issue:
+            </p>
+            <ul className="muted" style={{ marginTop: 0 }} data-testid="report-disclosures">
+              {preview.disclosures.map((line) => (
+                <li key={line}>{line}</li>
+              ))}
+            </ul>
+            <p className="muted">
+              File size: {(preview.sizeBytes / 1024).toFixed(0)} KB · No sample values, no file
+              contents, no folder paths.
+            </p>
+            <div className="row">
+              <button
+                className="primary"
+                onClick={() => void submit()}
+                disabled={busy}
+                data-testid="report-submit"
+              >
+                {busy ? 'Preparing…' : 'Download and open issue'}
+              </button>
+              <button onClick={() => setPreview(null)} disabled={busy} data-testid="report-cancel">
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+
+        {filed && (
+          <p className="muted" style={{ marginTop: 12 }} data-testid="report-filed">
+            Saved <code>{filed.fileName}</code> — attach it to the issue that just opened. If no
+            tab appeared, your browser blocked the pop-up:{' '}
+            <a href={filed.issueUrl} target="_blank" rel="noreferrer">
+              open the issue form
+            </a>
+            .
+          </p>
+        )}
+        {failed && (
+          <p className="fault" style={{ marginTop: 12 }} data-testid="report-error">
+            Could not build the report: {failed}
+          </p>
+        )}
       </div>
 
       <div className="panel">

--- a/Software/Control/tools/view-diagnostics.mjs
+++ b/Software/Control/tools/view-diagnostics.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/**
+ * Render a mad-diagnostics-*.json bundle as a readable report.
+ *
+ * The bundle is built to be complete, not to be read: 5000 log entries and
+ * base64 serial chunks are the right wire format and the wrong thing to open in
+ * an editor. This prints the triage summary, the merged timeline, and — the
+ * part that is otherwise unusable — an annotated hex dump of the raw serial
+ * window with inter-chunk timing.
+ *
+ *   node tools/view-diagnostics.mjs report.json
+ *   node tools/view-diagnostics.mjs report.json --bytes        # hex dump too
+ *   node tools/view-diagnostics.mjs report.json --level warn   # filter
+ *   node tools/view-diagnostics.mjs report.json --cat proto,flash
+ *   node tools/view-diagnostics.mjs report.json --previous     # prior session
+ */
+
+import { readFile } from 'node:fs/promises';
+
+const LEVELS = { debug: 10, info: 20, warn: 30, error: 40 };
+const COLOR = process.stdout.isTTY && !process.env.NO_COLOR;
+const c = (code, s) => (COLOR ? `\x1b[${code}m${s}\x1b[0m` : s);
+const dim = (s) => c('2', s);
+const bold = (s) => c('1', s);
+const paint = {
+  debug: (s) => dim(s),
+  info: (s) => s,
+  warn: (s) => c('33', s),
+  error: (s) => c('31', s),
+};
+
+function parseArgs(argv) {
+  const args = { file: null, bytes: false, level: 'debug', cats: null, previous: false, limit: 0 };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--bytes') args.bytes = true;
+    else if (a === '--previous') args.previous = true;
+    else if (a === '--level') args.level = argv[++i];
+    else if (a === '--cat') args.cats = new Set(argv[++i].split(','));
+    else if (a === '--limit') args.limit = Number(argv[++i]);
+    else if (!a.startsWith('--')) args.file = a;
+  }
+  return args;
+}
+
+const clock = (t) => new Date(t).toISOString().slice(11, 23);
+
+function renderTimeline(entries, args) {
+  const min = LEVELS[args.level] ?? LEVELS.debug;
+  let shown = entries.filter((e) => (LEVELS[e.level] ?? 0) >= min);
+  if (args.cats) shown = shown.filter((e) => args.cats.has(e.cat));
+  if (args.limit > 0) shown = shown.slice(-args.limit);
+
+  for (const e of shown) {
+    const thread = e.thread === 'worker' ? 'W' : 'M';
+    const head = `${clock(e.t)} ${e.level.padEnd(5)} ${thread} ${e.cat}/${e.tag}`;
+    const data = e.data ? ` ${dim(JSON.stringify(e.data))}` : '';
+    console.log(`${paint[e.level] ? paint[e.level](head) : head} ${e.msg ?? ''}${data}`.trimEnd());
+  }
+  const hidden = entries.length - shown.length;
+  if (hidden > 0) console.log(dim(`  … ${hidden} entries hidden by filters`));
+}
+
+/** Classic offset + hex + ASCII dump. */
+function hexDump(bytes, indent = '  ') {
+  const lines = [];
+  for (let off = 0; off < bytes.length; off += 16) {
+    const slice = bytes.subarray(off, off + 16);
+    const hex = [...slice].map((b) => b.toString(16).padStart(2, '0')).join(' ').padEnd(47);
+    const ascii = [...slice].map((b) => (b >= 0x20 && b < 0x7f ? String.fromCharCode(b) : '.')).join('');
+    lines.push(`${indent}${off.toString(16).padStart(6, '0')}  ${hex}  |${ascii}|`);
+  }
+  return lines.join('\n');
+}
+
+function renderSerial(tail) {
+  console.log(bold('\n── Raw serial window ──'));
+  console.log(
+    `${tail.chunks.length} chunks · ${tail.totalRxBytes} B received · ${tail.totalTxBytes} B sent · ` +
+      `capacity ${(tail.capacityBytes / 1024).toFixed(0)} KiB` +
+      (tail.droppedChunks > 0 ? ` · ${tail.droppedChunks} chunks evicted` : ''),
+  );
+  let prev = null;
+  for (const chunk of tail.chunks) {
+    // Inter-chunk gaps are the signal: a frame split across two reads with a
+    // long pause between them looks nothing like one that arrived whole.
+    const gap = prev === null ? '' : dim(` (+${(chunk.at - prev).toFixed(1)} ms)`);
+    prev = chunk.at;
+    const dir = chunk.dir === 'rx' ? c('36', 'RX') : c('35', 'TX');
+    const clipped = chunk.clipped ? dim(` [${chunk.clipped} B overwritten]`) : '';
+    console.log(`\n${clock(chunk.at)} ${dir} ${chunk.len} B${gap}${clipped}`);
+    console.log(hexDump(Buffer.from(chunk.b64, 'base64')));
+  }
+}
+
+function renderTriage(t) {
+  if (!t) return;
+  console.log(bold('── Summary ──'));
+  console.log(t.headline);
+  console.log(
+    `Session ${(t.sessionMs / 1000).toFixed(1)}s · ${t.entries} entries` +
+      (t.dropped > 0 ? ` (+${t.dropped} evicted)` : ''),
+  );
+  console.log(
+    `Link: ${t.everConnected ? 'connected' : c('31', 'never connected')}` +
+      (t.everConnected ? (t.everResponded ? ', responded' : c('33', ', never responded')) : ''),
+  );
+  for (const flag of t.flags ?? []) console.log(c('33', `  ! ${flag}`));
+  if (t.firstError) console.log(`First error: ${t.firstError.tag} ${t.firstError.msg}`);
+  for (const f of t.topFailures ?? []) console.log(dim(`  ${f.tag}: ${f.count}`));
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.file) {
+    console.error('usage: node tools/view-diagnostics.mjs <bundle.json> [--bytes] [--level warn] [--cat proto] [--previous] [--limit N]');
+    process.exit(2);
+  }
+  const bundle = JSON.parse(await readFile(args.file, 'utf8'));
+
+  console.log(bold(`MaD diagnostics · ${bundle.generatedAt ?? 'unknown time'}`));
+  console.log(
+    `app ${bundle.version ?? '?'} (${bundle.gitSha ?? '?'}) · firmware ${
+      bundle.device?.firmwareVersion ?? 'unknown'
+    } · ${bundle.buildMode ?? '?'}`,
+  );
+  console.log(dim(bundle.userAgent ?? ''));
+  console.log();
+  renderTriage(bundle.triage);
+
+  if (args.previous) {
+    const prev = bundle.previousSession;
+    if (!prev) {
+      console.log('\nNo previous session was attached to this bundle.');
+      return;
+    }
+    console.log(
+      bold(`\n── Previous session ${prev.id} ──`) +
+        (prev.closed ? '' : c('33', ' (ended unexpectedly)')),
+    );
+    renderTimeline(prev.entries ?? [], args);
+    return;
+  }
+
+  console.log(bold('\n── Timeline ──'));
+  renderTimeline(bundle.log?.entries ?? [], args);
+
+  if (bundle.previousSession) {
+    console.log(
+      dim(
+        `\n(a previous session's log is attached — ${bundle.previousSession.entries?.length ?? 0} entries; pass --previous)`,
+      ),
+    );
+  }
+  if (args.bytes && bundle.serialTail) renderSerial(bundle.serialTail);
+  else if (bundle.serialTail) {
+    console.log(dim(`\n(${bundle.serialTail.chunks.length} serial chunks captured; pass --bytes)`));
+  }
+}
+
+main().catch((err) => {
+  console.error(err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Why this exists

[#56](https://github.com/RileyMcCarthy/MaD/pull/56) was merged into `chore/remove-electron-app`, but [#55](https://github.com/RileyMcCarthy/MaD/pull/55) had already carried that branch into `main` the day before. The merge succeeded and the work never reached `main` — the branch is now stranded 9 commits ahead with no open PR.

`main` currently has the original session logger (via #55) but is missing everything from #56.

## What this restores

- **Firmware-flash instrumentation** — `src/firmware/` had zero logging despite being the newest and most failure-prone serial path. Now logs reset, each boot-ROM detect attempt with the ROM's actual reply, upload deciles, checksum verify, and which phase a failure died in.
- **IndexedDB persistence** — "it froze so I restarted it" no longer destroys the evidence. Attaches the previous session to a bundle; `closed: false` marks one that never shut down cleanly.
- **Triage summary** — first error *and* last (cause vs symptom), ranked failure counters, actionable flags. Leads every bundle and issue.
- **Review-before-send preview** — the report becomes a public issue, so the user sees the actual contents and identifying details rather than ticking a box. Publishes the reviewed bundle, not a rebuilt one.
- **`tools/view-diagnostics.mjs`** — triage, filterable timeline, and an annotated hex dump with inter-chunk timing.
- **Correlation ids, undecodable-traffic detection, steady-state ring backoff** (~83 min → ~14 h of retained history).
- **9-check diagnostics e2e suite gating CI**, using a scripted fake serial so it needs no emulator or bridge.

## Conflict resolution

One conflict, in `About.tsx`, purely over formatting: `main` had reformatted the firmware-releases link across lines while #56 fixed the same placeholder URL on one line. Kept main's formatting. #54's Firmware panel (`To update firmware, see the Firmware page`) is preserved — that panel was deliberately left alone throughout precisely to keep this collision small.

## Verification

Verified against `main` rather than assumed. `npm run verify` green — **331 tests across 24 files**, lint clean, production build.

One wrinkle worth recording: the first verify run failed with `loadCellCapacity` type errors. That was contamination from copying generated protocol code out of a working tree that has an in-progress `MaDProtocol.yaml` change — not a problem with the cherry-pick. Regenerating from main's own schema cleared it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)